### PR TITLE
added option to not sort

### DIFF
--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -129,7 +129,10 @@ class WorstCaseAttack(Attack):
                 self.dummy_attack_metrics += temp_metrics
         logger.info("Finished running attacks")
 
-    def _prepare_attack_data(self, train_preds: np.ndarray, test_preds: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def _prepare_attack_data(
+        self,
+        train_preds: np.ndarray,
+        test_preds: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Prepare training data and labels for attack model
         Combines the train and test preds into a single numpy array (optionally) sorting each
         row to have the highest probabilities in the first column. Constructs a label array that

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -40,6 +40,7 @@ class WorstCaseAttackArgs:
         self.__dict__["in_sample_filename"] = None
         self.__dict__["out_sample_filename"] = None
         self.__dict__["report_name"] = None
+        self.__dict__["sort_probs"] = True
         self.__dict__.update(kwargs)
 
     def __str__(self):
@@ -128,6 +129,26 @@ class WorstCaseAttack(Attack):
                 self.dummy_attack_metrics += temp_metrics
         logger.info("Finished running attacks")
 
+    def _prepare_attack_data(self, train_preds: np.ndarray, test_preds: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Prepare training data and labels for attack model
+        Combines the train and test preds into a single numpy array (optionally) sorting each
+        row to have the highest probabilities in the first column. Constructs a label array that
+        has ones corresponding to training rows and zeros to testing rows."""
+        logger = logging.getLogger("prep-attack-data")
+        if self.args.sort_probs:
+            logger.info("Sorting probabilities to leave highest value in first column")
+            train_preds = -np.sort(-train_preds, axis=1)
+            test_preds = -np.sort(-test_preds, axis=1)
+        
+        logger.info("Creating MIA data")
+        mi_x = np.vstack((train_preds, test_preds))
+        mi_y = np.hstack((np.ones(len(train_preds)), np.zeros(len(test_preds))))
+
+        return (mi_x, mi_y)
+
+        
+
+
     def run_attack_reps(self, train_preds: np.ndarray, test_preds: np.ndarray) -> list:
         """
         Run actual attack reps from train and test predictions
@@ -147,13 +168,8 @@ class WorstCaseAttack(Attack):
         self.args.set_param("n_rows_in", len(train_preds))
         self.args.set_param("n_rows_out", len(test_preds))
         logger = logging.getLogger("attack-reps")
-        logger.info("Sorting probabilities to leave highest value in first column")
-        train_preds = -np.sort(-train_preds, axis=1)
-        test_preds = -np.sort(-test_preds, axis=1)
 
-        logger.info("Creating MIA data")
-        mi_x = np.vstack((train_preds, test_preds))
-        mi_y = np.hstack((np.ones(len(train_preds)), np.zeros(len(test_preds))))
+        mi_x, mi_y = self._prepare_attack_data(train_preds, test_preds)
 
         mia_metrics = []
         for rep in range(self.args.n_reps):
@@ -537,6 +553,20 @@ def main():
         required=False,
         dest="p_thresh",
         help=("P-value threshold for significance testing. Default = %(default)f"),
+    )
+
+    attack_parser.add_argument(
+        "--sort-probs",
+        action="store",
+        type=bool,
+        default=True,
+        required=False,
+        dest="sort_probs",
+        help=(
+            "Whether or not to sort the output probabilities (per row) before "
+            "using them to train the attack model. Default = %(default)f"
+        )
+
     )
 
     attack_parser.set_defaults(func=_run_attack)

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -160,7 +160,7 @@ def test_attack_data_prep():
     train_preds = np.array([[1, 0], [0, 1]], int)
     test_preds = np.array([[2, 0], [0, 2]], int)
 
-    mi_x, mi_y = attack_obj._prepare_attack_data( # pylint: disable=protected-access
+    mi_x, mi_y = attack_obj._prepare_attack_data(  # pylint: disable=protected-access
         train_preds, test_preds
     )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
@@ -170,7 +170,7 @@ def test_attack_data_prep():
     # With sort_probs = False, the rows of x should not be sorted
     args = worst_case_attack.WorstCaseAttackArgs(sort_probs=False)
     attack_obj = worst_case_attack.WorstCaseAttack(args)
-    mi_x, mi_y = attack_obj._prepare_attack_data( # pylint: disable=protected-access
+    mi_x, mi_y = attack_obj._prepare_attack_data(  # pylint: disable=protected-access
         train_preds, test_preds
     )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -159,7 +159,7 @@ def test_attack_data_prep():
     train_preds = np.array([[1, 0], [0, 1]], int)
     test_preds = np.array([[2, 0], [0, 2]], int)
 
-    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds)
+    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds) # pylint: disable=protected-access
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     # Test the x data produced. Each row should be sorted in descending order
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [1, 0], [2, 0], [2, 0]]))
@@ -167,7 +167,7 @@ def test_attack_data_prep():
     # With sort_probs = False, the rows of x should not be sorted
     args = worst_case_attack.WorstCaseAttackArgs(sort_probs=False)
     attack_obj = worst_case_attack.WorstCaseAttack(args)
-    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds)
+    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds) # pylint: disable=protected-access
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
 

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -160,7 +160,9 @@ def test_attack_data_prep():
     train_preds = np.array([[1, 0], [0, 1]], int)
     test_preds = np.array([[2, 0], [0, 2]], int)
 
-    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds) # pylint: disable=protected-access
+    mi_x, mi_y = attack_obj._prepare_attack_data(
+        train_preds, test_preds
+    )  # pylint: disable=protected-access
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     # Test the x data produced. Each row should be sorted in descending order
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [1, 0], [2, 0], [2, 0]]))
@@ -168,7 +170,9 @@ def test_attack_data_prep():
     # With sort_probs = False, the rows of x should not be sorted
     args = worst_case_attack.WorstCaseAttackArgs(sort_probs=False)
     attack_obj = worst_case_attack.WorstCaseAttack(args)
-    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds) # pylint: disable=protected-access
+    mi_x, mi_y = attack_obj._prepare_attack_data(
+        train_preds, test_preds
+    )  # pylint: disable=protected-access
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
 

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -152,6 +152,25 @@ def test_dummy_data():
     attack_obj = worst_case_attack.WorstCaseAttack(args)
     attack_obj.make_dummy_data()
 
+def test_attack_data_prep():
+    """test the method that prepares the attack data"""
+    args = worst_case_attack.WorstCaseAttackArgs()
+    attack_obj = worst_case_attack.WorstCaseAttack(args)
+    train_preds = np.array([[1, 0], [0, 1]], int)
+    test_preds = np.array([[2, 0], [0, 2]], int)
+
+    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds)
+    np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
+    # Test the x data produced. Each row should be sorted in descending order
+    np.testing.assert_array_equal(mi_x, np.array([[1, 0], [1, 0], [2, 0], [2, 0]]))
+
+    # With sort_probs = False, the rows of x should not be sorted
+    args = worst_case_attack.WorstCaseAttackArgs(sort_probs=False)
+    attack_obj = worst_case_attack.WorstCaseAttack(args)
+    mi_x, mi_y = attack_obj._prepare_attack_data(train_preds, test_preds)
+    np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
+    np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
+
 
 def test_main():
     """test invocation via command line"""

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -160,9 +160,9 @@ def test_attack_data_prep():
     train_preds = np.array([[1, 0], [0, 1]], int)
     test_preds = np.array([[2, 0], [0, 2]], int)
 
-    mi_x, mi_y = attack_obj._prepare_attack_data(
+    mi_x, mi_y = attack_obj._prepare_attack_data( # pylint: disable=protected-access
         train_preds, test_preds
-    )  # pylint: disable=protected-access
+    )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     # Test the x data produced. Each row should be sorted in descending order
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [1, 0], [2, 0], [2, 0]]))
@@ -170,9 +170,9 @@ def test_attack_data_prep():
     # With sort_probs = False, the rows of x should not be sorted
     args = worst_case_attack.WorstCaseAttackArgs(sort_probs=False)
     attack_obj = worst_case_attack.WorstCaseAttack(args)
-    mi_x, mi_y = attack_obj._prepare_attack_data(
+    mi_x, mi_y = attack_obj._prepare_attack_data( # pylint: disable=protected-access
         train_preds, test_preds
-    )  # pylint: disable=protected-access
+    )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
 


### PR DESCRIPTION
Closes #89 

The standard behaviour in MI attacks is to use the _sorted_ predictive probabilities as features. I.e. feature one is the highest probability. This makes the attack easier and less nonlinear (in an ad hoc kind of way of thinking).

This won't always be relevant so I've added an option to not sort them.

Also refactored part of `WorstCaseAttack` to expose this operation for testing.