### PR TITLE
93 add option to include target model error into attacks as a feature

### DIFF
--- a/aisdc/attacks/report.py
+++ b/aisdc/attacks/report.py
@@ -1,6 +1,6 @@
 """Code for automatic report generation"""
 import json
-
+import abc
 import numpy as np
 import pylab as plt
 from fpdf import FPDF
@@ -83,6 +83,8 @@ class NumpyArrayEncoder(json.JSONEncoder):
             return int(o)
         if isinstance(o, np.int32):
             return int(o)
+        if isinstance(o, abc.ABCMeta):
+            return str(o)
         return json.JSONEncoder.default(self, o)
 
 

--- a/aisdc/attacks/report.py
+++ b/aisdc/attacks/report.py
@@ -1,6 +1,7 @@
 """Code for automatic report generation"""
-import json
 import abc
+import json
+
 import numpy as np
 import pylab as plt
 from fpdf import FPDF

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -138,7 +138,13 @@ class WorstCaseAttack(Attack):
         """
         logger = logging.getLogger("attack-from-preds")
         logger.info("Running main attack repetitions")
-        self.attack_metrics = self.run_attack_reps(train_preds, test_preds)
+        self.attack_metrics = self.run_attack_reps(
+            train_preds,
+            test_preds,
+            train_correct=train_correct,
+            test_correct=test_correct
+        )
+
         if self.args.n_dummy_reps > 0:
             logger.info("Running dummy attack reps")
             self.dummy_attack_metrics = []
@@ -168,7 +174,7 @@ class WorstCaseAttack(Attack):
 
         logger.info("Creating MIA data")
 
-        if self.args.include_model_correct_feature:
+        if self.args.include_model_correct_feature and train_correct is not None:
             train_preds = np.hstack((train_preds, train_correct[:, None]))
             test_preds = np.hstack((test_preds, test_correct[:, None]))
             
@@ -200,7 +206,6 @@ class WorstCaseAttack(Attack):
         self.args.set_param("n_rows_in", len(train_preds))
         self.args.set_param("n_rows_out", len(test_preds))
         logger = logging.getLogger("attack-reps")
-
         mi_x, mi_y = self._prepare_attack_data(
             train_preds,
             test_preds,

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -172,7 +172,10 @@ class WorstCaseAttack(Attack):
 
         return (mi_x, mi_y)
 
-    def run_attack_reps(self, train_preds: np.ndarray, test_preds: np.ndarray, train_correct: np.ndarray=None, test_correct: np.ndarray=None) -> list:
+    def run_attack_reps(
+        self, train_preds: np.ndarray, test_preds: np.ndarray,
+        train_correct: np.ndarray=None, test_correct: np.ndarray=None
+    ) -> list:
         """
         Run actual attack reps from train and test predictions
 
@@ -192,7 +195,12 @@ class WorstCaseAttack(Attack):
         self.args.set_param("n_rows_out", len(test_preds))
         logger = logging.getLogger("attack-reps")
 
-        mi_x, mi_y = self._prepare_attack_data(train_preds, test_preds, train_correct, test_correct)
+        mi_x, mi_y = self._prepare_attack_data(
+            train_preds,
+            test_preds,
+            train_correct,
+            test_correct
+        )
 
         mia_metrics = []
         for rep in range(self.args.n_reps):

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -592,18 +592,20 @@ def main():
         help=("P-value threshold for significance testing. Default = %(default)f")
     )
 
-    attack_parser.add_argument(
-        "--include-correct",
-        action="store",
-        type=bool,
-        required=False,
-        default=False,
-        dest='include_model_correct_feature',
-        help=(
-            "Whether or not to include an additional feature into the MIA attack model that "
-            "holds whether or not the target model made a correct predicion for each example."
-        ),
-    )
+    # Not currently possible from the command line as we cannot compute the correctness
+    # of predictions. Possibly to be added in the future
+    # attack_parser.add_argument(
+    #     "--include-correct",
+    #     action="store",
+    #     type=bool,
+    #     required=False,
+    #     default=False,
+    #     dest='include_model_correct_feature',
+    #     help=(
+    #         "Whether or not to include an additional feature into the MIA attack model that "
+    #         "holds whether or not the target model made a correct predicion for each example."
+    #     ),
+    # )
     
     attack_parser.add_argument(
         "--sort-probs",

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -14,8 +14,8 @@ from typing import Any
 import numpy as np
 import sklearn
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import train_test_split
 from sklearn.metrics import confusion_matrix
+from sklearn.model_selection import train_test_split
 
 from aisdc.attacks import metrics, report
 from aisdc.attacks.attack import Attack
@@ -45,9 +45,9 @@ class WorstCaseAttackArgs:
         self.__dict__["sort_probs"] = True
         self.__dict__["mia_attack_model"] = RandomForestClassifier
         self.__dict__["mia_attack_model_hyp"] = {
-            'min_samples_split': 20,
-            'min_samples_leaf': 10,
-            'max_depth': 5
+            "min_samples_split": 20,
+            "min_samples_leaf": 10,
+            "max_depth": 5,
         }
         self.__dict__.update(kwargs)
 
@@ -97,15 +97,13 @@ class WorstCaseAttack(Attack):
             train_correct = 1 * (
                 dataset.y_train == target_model.predict(dataset.x_train)
             )
-            test_correct = 1 * (
-                dataset.y_test == target_model.predict(dataset.x_test)
-            )
+            test_correct = 1 * (dataset.y_test == target_model.predict(dataset.x_test))
 
         self.attack_from_preds(
             train_preds,
             test_preds,
             train_correct=train_correct,
-            test_correct=test_correct
+            test_correct=test_correct,
         )
 
     def attack_from_prediction_files(self):
@@ -121,8 +119,11 @@ class WorstCaseAttack(Attack):
         self.attack_from_preds(train_preds, test_preds)
 
     def attack_from_preds(  # pylint: disable=too-many-locals
-        self, train_preds: np.ndarray, test_preds: np.ndarray,
-        train_correct: np.ndarray=None, test_correct: np.ndarray=None
+        self,
+        train_preds: np.ndarray,
+        test_preds: np.ndarray,
+        train_correct: np.ndarray = None,
+        test_correct: np.ndarray = None,
     ) -> None:
         """
         Runs the attack based upon the predictions in train_preds and test_preds, and the params
@@ -143,7 +144,7 @@ class WorstCaseAttack(Attack):
             train_preds,
             test_preds,
             train_correct=train_correct,
-            test_correct=test_correct
+            test_correct=test_correct,
         )
 
         if self.args.n_dummy_reps > 0:
@@ -160,8 +161,11 @@ class WorstCaseAttack(Attack):
         logger.info("Finished running attacks")
 
     def _prepare_attack_data(
-        self, train_preds: np.ndarray, test_preds: np.ndarray,
-        train_correct: np.ndarray=None, test_correct: np.ndarray=None
+        self,
+        train_preds: np.ndarray,
+        test_preds: np.ndarray,
+        train_correct: np.ndarray = None,
+        test_correct: np.ndarray = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Prepare training data and labels for attack model
         Combines the train and test preds into a single numpy array (optionally) sorting each
@@ -178,7 +182,6 @@ class WorstCaseAttack(Attack):
         if self.args.include_model_correct_feature and train_correct is not None:
             train_preds = np.hstack((train_preds, train_correct[:, None]))
             test_preds = np.hstack((test_preds, test_correct[:, None]))
-            
 
         mi_x = np.vstack((train_preds, test_preds))
         mi_y = np.hstack((np.ones(len(train_preds)), np.zeros(len(test_preds))))
@@ -186,8 +189,11 @@ class WorstCaseAttack(Attack):
         return (mi_x, mi_y)
 
     def run_attack_reps(
-        self, train_preds: np.ndarray, test_preds: np.ndarray,
-        train_correct: np.ndarray=None, test_correct: np.ndarray=None
+        self,
+        train_preds: np.ndarray,
+        test_preds: np.ndarray,
+        train_correct: np.ndarray = None,
+        test_correct: np.ndarray = None,
     ) -> list:
         """
         Run actual attack reps from train and test predictions
@@ -208,10 +214,7 @@ class WorstCaseAttack(Attack):
         self.args.set_param("n_rows_out", len(test_preds))
         logger = logging.getLogger("attack-reps")
         mi_x, mi_y = self._prepare_attack_data(
-            train_preds,
-            test_preds,
-            train_correct,
-            test_correct
+            train_preds, test_preds, train_correct, test_correct
         )
 
         mia_metrics = []
@@ -220,7 +223,9 @@ class WorstCaseAttack(Attack):
             mi_train_x, mi_test_x, mi_train_y, mi_test_y = train_test_split(
                 mi_x, mi_y, test_size=self.args.test_prop, stratify=mi_y
             )
-            attack_classifier = self.args.mia_attack_model(**self.args.mia_attack_model_hyp)
+            attack_classifier = self.args.mia_attack_model(
+                **self.args.mia_attack_model_hyp
+            )
             attack_classifier.fit(mi_train_x, mi_train_y)
 
             mia_metrics.append(
@@ -234,9 +239,9 @@ class WorstCaseAttack(Attack):
                 yeom_tpr = tp / (tp + fn)
                 yeom_fpr = fp / (fp + tn)
                 yeom_advantage = yeom_tpr - yeom_fpr
-                mia_metrics[-1]['yeom_tpr'] = yeom_tpr
-                mia_metrics[-1]['yeom_fpr'] = yeom_fpr
-                mia_metrics[-1]['yeom_advantage'] = yeom_advantage
+                mia_metrics[-1]["yeom_tpr"] = yeom_tpr
+                mia_metrics[-1]["yeom_fpr"] = yeom_fpr
+                mia_metrics[-1]["yeom_advantage"] = yeom_advantage
 
         logger.info("Finished simulating attacks")
 
@@ -606,7 +611,7 @@ def main():
         default=P_THRESH,
         required=False,
         dest="p_thresh",
-        help=("P-value threshold for significance testing. Default = %(default)f")
+        help=("P-value threshold for significance testing. Default = %(default)f"),
     )
 
     # Not currently possible from the command line as we cannot compute the correctness
@@ -623,7 +628,7 @@ def main():
     #         "holds whether or not the target model made a correct predicion for each example."
     #     ),
     # )
-    
+
     attack_parser.add_argument(
         "--sort-probs",
         action="store",

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -15,6 +15,7 @@ import numpy as np
 import sklearn
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+from sklearn.metrics import confusion_matrix
 
 from aisdc.attacks import metrics, report
 from aisdc.attacks.attack import Attack
@@ -225,6 +226,17 @@ class WorstCaseAttack(Attack):
             mia_metrics.append(
                 metrics.get_metrics(attack_classifier, mi_test_x, mi_test_y)
             )
+
+            if self.args.include_model_correct_feature and train_correct is not None:
+                # Compute the Yeom TPR and FPR
+                yeom_preds = mi_test_x[:, -1]
+                tn, fp, fn, tp = confusion_matrix(mi_test_y, yeom_preds).ravel()
+                yeom_tpr = tp / (tp + fn)
+                yeom_fpr = fp / (fp + tn)
+                yeom_advantage = yeom_tpr - yeom_fpr
+                mia_metrics[-1]['yeom_tpr'] = yeom_tpr
+                mia_metrics[-1]['yeom_fpr'] = yeom_fpr
+                mia_metrics[-1]['yeom_advantage'] = yeom_advantage
 
         logger.info("Finished simulating attacks")
 

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -42,6 +42,12 @@ class WorstCaseAttackArgs:
         self.__dict__["report_name"] = None
         self.__dict__["include_model_correct_feature"] = False
         self.__dict__["sort_probs"] = True
+        self.__dict__["mia_attack_model"] = RandomForestClassifier
+        self.__dict__["mia_attack_model_hyp"] = {
+            'min_samples_split': 20,
+            'min_samples_leaf': 10,
+            'max_depth': 5
+        }
         self.__dict__.update(kwargs)
 
     def __str__(self):
@@ -208,7 +214,7 @@ class WorstCaseAttack(Attack):
             mi_train_x, mi_test_x, mi_train_y, mi_test_y = train_test_split(
                 mi_x, mi_y, test_size=self.args.test_prop, stratify=mi_y
             )
-            attack_classifier = RandomForestClassifier()
+            attack_classifier = self.args.mia_attack_model(**self.args.mia_attack_model_hyp)
             attack_classifier.fit(mi_train_x, mi_train_y)
 
             mia_metrics.append(

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -188,7 +188,7 @@ class WorstCaseAttack(Attack):
 
         return (mi_x, mi_y)
 
-    def run_attack_reps(
+    def run_attack_reps( # pylint: disable = too-many-locals
         self,
         train_preds: np.ndarray,
         test_preds: np.ndarray,
@@ -236,12 +236,10 @@ class WorstCaseAttack(Attack):
                 # Compute the Yeom TPR and FPR
                 yeom_preds = mi_test_x[:, -1]
                 tn, fp, fn, tp = confusion_matrix(mi_test_y, yeom_preds).ravel()
-                yeom_tpr = tp / (tp + fn)
-                yeom_fpr = fp / (fp + tn)
-                yeom_advantage = yeom_tpr - yeom_fpr
-                mia_metrics[-1]["yeom_tpr"] = yeom_tpr
-                mia_metrics[-1]["yeom_fpr"] = yeom_fpr
-                mia_metrics[-1]["yeom_advantage"] = yeom_advantage
+                mia_metrics[-1]["yeom_tpr"] = tp / (tp + fn)
+                mia_metrics[-1]["yeom_fpr"] = fp / (fp + tn)
+                mia_metrics[-1]["yeom_advantage"] = mia_metrics[-1]["yeom_tpr"] -\
+                     mia_metrics[-1]["yeom_fpr"]
 
         logger.info("Finished simulating attacks")
 

--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -188,7 +188,7 @@ class WorstCaseAttack(Attack):
 
         return (mi_x, mi_y)
 
-    def run_attack_reps( # pylint: disable = too-many-locals
+    def run_attack_reps(  # pylint: disable = too-many-locals
         self,
         train_preds: np.ndarray,
         test_preds: np.ndarray,
@@ -238,8 +238,9 @@ class WorstCaseAttack(Attack):
                 tn, fp, fn, tp = confusion_matrix(mi_test_y, yeom_preds).ravel()
                 mia_metrics[-1]["yeom_tpr"] = tp / (tp + fn)
                 mia_metrics[-1]["yeom_fpr"] = fp / (fp + tn)
-                mia_metrics[-1]["yeom_advantage"] = mia_metrics[-1]["yeom_tpr"] -\
-                     mia_metrics[-1]["yeom_fpr"]
+                mia_metrics[-1]["yeom_advantage"] = (
+                    mia_metrics[-1]["yeom_tpr"] - mia_metrics[-1]["yeom_fpr"]
+                )
 
         logger.info("Finished simulating attacks")
 

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -91,6 +91,12 @@ def test_attack_with_correct_feature():
     attack_obj = worst_case_attack.WorstCaseAttack(args)
     attack_obj.attack(dataset_obj, target_model)
 
+    # Check that attack_metrics has the Yeom metrics
+    assert 'yeom_tpr' in attack_obj.attack_metrics[0]
+    assert 'yeom_fpr' in attack_obj.attack_metrics[0]
+    assert 'yeom_advantage' in attack_obj.attack_metrics[0]
+
+
 
 def test_attack_from_predictions():
     """checks code that runs attacks from predictions"""

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -83,7 +83,7 @@ def test_attack_with_correct_feature():
         in_sample_filename=None,
         out_sample_filename=None,
         test_prop=0.5,
-        report_name="test-10reps",
+        report_name="test-1rep",
         include_model_correct_feature=True
     )
 

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -176,6 +176,38 @@ def test_attack_data_prep():
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
 
+def test_attack_data_prep_with_correct_feature():
+    """test the method that prepares the attack data.
+    This time, testing that the model correctness values are added, are always
+    the final feature, and are not included in the sorting"""
+    args = worst_case_attack.WorstCaseAttackArgs(include_model_correct_feature=True)
+    attack_obj = worst_case_attack.WorstCaseAttack(args)
+    train_preds = np.array([[1, 0], [0, 1]], int)
+    test_preds = np.array([[2, 0], [0, 2]], int)
+    train_correct = np.array([1, 0], int)
+    test_correct = np.array([0, 1], int)
+
+    mi_x, mi_y = attack_obj._prepare_attack_data(  # pylint: disable=protected-access
+        train_preds, test_preds, train_correct=train_correct, test_correct=test_correct
+    )
+    np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
+    # Test the x data produced. Each row should be sorted in descending order
+    np.testing.assert_array_equal(mi_x, np.array([[1, 0, 1], [1, 0, 0], [2, 0, 0], [2, 0, 1]]))
+
+    # With sort_probs = False, the rows of x should not be sorted
+    args = worst_case_attack.WorstCaseAttackArgs(
+        sort_probs=False,
+        include_model_correct_feature=True
+    )
+    attack_obj = worst_case_attack.WorstCaseAttack(args)
+    mi_x, mi_y = attack_obj._prepare_attack_data(  # pylint: disable=protected-access
+        train_preds, test_preds, train_correct=train_correct, test_correct=test_correct
+    )
+    np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
+    np.testing.assert_array_equal(mi_x, np.array([[1, 0, 1], [0, 1, 0], [2, 0, 0], [0, 2, 1]]))
+
+
+
 
 def test_main():
     """test invocation via command line"""

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -4,9 +4,9 @@ Copyright (C) Jim Smith 2022 <james.smith@uwe.ac.uk>
 import os
 import sys
 from unittest.mock import patch
-import pytest
 
 import numpy as np
+import pytest
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
@@ -65,6 +65,7 @@ def test_report_worstcase():
     attack_obj.attack(dataset_obj, target_model)
     _ = attack_obj.make_report()
 
+
 def test_attack_with_correct_feature():
     X, y = load_breast_cancer(return_X_y=True, as_frame=False)
     train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.3)
@@ -84,7 +85,7 @@ def test_attack_with_correct_feature():
         out_sample_filename=None,
         test_prop=0.5,
         report_name="test-1rep",
-        include_model_correct_feature=True
+        include_model_correct_feature=True,
     )
 
     # with multiple reps
@@ -92,10 +93,9 @@ def test_attack_with_correct_feature():
     attack_obj.attack(dataset_obj, target_model)
 
     # Check that attack_metrics has the Yeom metrics
-    assert 'yeom_tpr' in attack_obj.attack_metrics[0]
-    assert 'yeom_fpr' in attack_obj.attack_metrics[0]
-    assert 'yeom_advantage' in attack_obj.attack_metrics[0]
-
+    assert "yeom_tpr" in attack_obj.attack_metrics[0]
+    assert "yeom_fpr" in attack_obj.attack_metrics[0]
+    assert "yeom_advantage" in attack_obj.attack_metrics[0]
 
 
 def test_attack_from_predictions():
@@ -209,6 +209,7 @@ def test_attack_data_prep():
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     np.testing.assert_array_equal(mi_x, np.array([[1, 0], [0, 1], [2, 0], [0, 2]]))
 
+
 def test_attack_data_prep_with_correct_feature():
     """test the method that prepares the attack data.
     This time, testing that the model correctness values are added, are always
@@ -225,30 +226,35 @@ def test_attack_data_prep_with_correct_feature():
     )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
     # Test the x data produced. Each row should be sorted in descending order
-    np.testing.assert_array_equal(mi_x, np.array([[1, 0, 1], [1, 0, 0], [2, 0, 0], [2, 0, 1]]))
+    np.testing.assert_array_equal(
+        mi_x, np.array([[1, 0, 1], [1, 0, 0], [2, 0, 0], [2, 0, 1]])
+    )
 
     # With sort_probs = False, the rows of x should not be sorted
     args = worst_case_attack.WorstCaseAttackArgs(
-        sort_probs=False,
-        include_model_correct_feature=True
+        sort_probs=False, include_model_correct_feature=True
     )
     attack_obj = worst_case_attack.WorstCaseAttack(args)
     mi_x, mi_y = attack_obj._prepare_attack_data(  # pylint: disable=protected-access
         train_preds, test_preds, train_correct=train_correct, test_correct=test_correct
     )
     np.testing.assert_array_equal(mi_y, np.array([1, 1, 0, 0], np.int))
-    np.testing.assert_array_equal(mi_x, np.array([[1, 0, 1], [0, 1, 0], [2, 0, 0], [0, 2, 1]]))
+    np.testing.assert_array_equal(
+        mi_x, np.array([[1, 0, 1], [0, 1, 0], [2, 0, 0], [0, 2, 1]])
+    )
+
 
 def test_non_rf_mia():
-    '''Tests that it is possible to set the attack model via the args
+    """Tests that it is possible to set the attack model via the args
     In this case, we set as a SVC. But we set probability to false. If the code does
     indeed try and use the SVC (as we want) it will fail as it will try and access
     the predict_proba which won't work if probability=False. Hence, if the code throws
-    an AttributeError we now it *is* trying to use the SVC'''
+    an AttributeError we now it *is* trying to use the SVC"""
     from sklearn.svm import SVC
+
     args = worst_case_attack.WorstCaseAttackArgs(
         mia_attack_model=SVC,
-        mia_attack_model_hyp={'kernel': 'rbf', 'probability': False}
+        mia_attack_model_hyp={"kernel": "rbf", "probability": False},
     )
 
     X, y = load_breast_cancer(return_X_y=True, as_frame=False)
@@ -264,8 +270,6 @@ def test_non_rf_mia():
     attack_obj = worst_case_attack.WorstCaseAttack(args)
     with pytest.raises(AttributeError):
         attack_obj.attack_from_preds(ytr_pred, yte_pred)
-
-
 
 
 def test_main():

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -65,6 +65,32 @@ def test_report_worstcase():
     attack_obj.attack(dataset_obj, target_model)
     _ = attack_obj.make_report()
 
+def test_attack_with_correct_feature():
+    X, y = load_breast_cancer(return_X_y=True, as_frame=False)
+    train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.3)
+    dataset_obj = dataset.Data()
+    dataset_obj.add_processed_data(train_X, train_y, test_X, test_y)
+
+    target_model = SVC(gamma=0.1, probability=True)
+    target_model.fit(train_X, train_y)
+
+    args = worst_case_attack.WorstCaseAttackArgs(
+        # How many attacks to run -- in each the attack model is trained on a different
+        # subset of the data
+        n_reps=1,
+        n_dummy_reps=1,
+        p_thresh=0.05,
+        in_sample_filename=None,
+        out_sample_filename=None,
+        test_prop=0.5,
+        report_name="test-10reps",
+        include_model_correct_feature=True
+    )
+
+    # with multiple reps
+    attack_obj = worst_case_attack.WorstCaseAttack(args)
+    attack_obj.attack(dataset_obj, target_model)
+
 
 def test_attack_from_predictions():
     """checks code that runs attacks from predictions"""

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -67,7 +67,7 @@ def test_report_worstcase():
 
 
 def test_attack_with_correct_feature():
-    '''Test the attack when the model correctness feature is used'''
+    """Test the attack when the model correctness feature is used"""
     X, y = load_breast_cancer(return_X_y=True, as_frame=False)
     train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.3)
     dataset_obj = dataset.Data()

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -67,6 +67,7 @@ def test_report_worstcase():
 
 
 def test_attack_with_correct_feature():
+    '''Test the attack when the model correctness feature is used'''
     X, y = load_breast_cancer(return_X_y=True, as_frame=False)
     train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.3)
     dataset_obj = dataset.Data()
@@ -250,7 +251,6 @@ def test_non_rf_mia():
     indeed try and use the SVC (as we want) it will fail as it will try and access
     the predict_proba which won't work if probability=False. Hence, if the code throws
     an AttributeError we now it *is* trying to use the SVC"""
-    from sklearn.svm import SVC
 
     args = worst_case_attack.WorstCaseAttackArgs(
         mia_attack_model=SVC,


### PR DESCRIPTION
Closes #93 
Closes #92 

Various things:
1. The attack model (and its hyperparams) can now be set via the Worst case args (but not from command line access)
2. The attack can include an extra feature that encodes whether or not the target model was correct on those examples. This is also only accessible programatically, as that information is not available when we just pass model predictions on the command line. Extending it to the command line is more work than I want to do at the moment.
3. If the extra feature is included, the attack computes a _baseline_ performance, using the Yeom bounded loss adversary. It's only computed in this situation as it needs the correctness of the target models predictions. Results are added to the metrics with the prefix `yeom_` -- `yeom_tpr`, `yeom_fpr`, `yeom_advantage` (tpr - fpr)