### PR TITLE
Fixing dummy_repos bug

### DIFF
--- a/aisdc/attacks/worst_case_attack.py
+++ b/aisdc/attacks/worst_case_attack.py
@@ -147,9 +147,9 @@ class WorstCaseAttack(Attack):
             test_correct=test_correct,
         )
 
+        self.dummy_attack_metrics = []
         if self.args.n_dummy_reps > 0:
             logger.info("Running dummy attack reps")
-            self.dummy_attack_metrics = []
             n_train_rows = len(train_preds)
             n_test_rows = len(test_preds)
             for _ in range(self.args.n_dummy_reps):
@@ -267,6 +267,9 @@ class WorstCaseAttack(Attack):
             )[0]
             for m in attack_metrics
         ]
+
+        if len(attack_metrics) == 0:
+            return global_metrics
 
         m = attack_metrics[0]
         _, auc_std = metrics.auc_p_val(

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -167,7 +167,7 @@ def test_attack_from_predictions_no_dummy():
     # with multiple reps
     attack_obj = worst_case_attack.WorstCaseAttack(args)
     attack_obj.attack_from_prediction_files()
-
+    attack_obj.make_report()
 
 def test_dummy_data():
     """test functionality around creating dummy data"""

--- a/tests/test_worst_case_attack.py
+++ b/tests/test_worst_case_attack.py
@@ -169,6 +169,7 @@ def test_attack_from_predictions_no_dummy():
     attack_obj.attack_from_prediction_files()
     attack_obj.make_report()
 
+
 def test_dummy_data():
     """test functionality around creating dummy data"""
     args = worst_case_attack.WorstCaseAttackArgs(


### PR DESCRIPTION
Issue #112 - make_report fails when n_dummy_reps is 0

Solution:
Make dummy_attack_metrics an empty list within attack_from_preds

In _get_global_metrics, check if attack_metrics is an empty array, and return the dictionary without any extra parameters if so