### PR TITLE
Move files for release (issue #193)

### DIFF
--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -572,7 +572,7 @@ class GenerateTextReport:
         self.text_out.append(bucket_text)
 
     def export_to_file(self, output_filename:str="summary.txt",
-        move_files = True,
+        move_files = False,
         model_filename = None,
         release_dir="release_files/",
         artefacts_dir="training_artefacts/"):

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -15,7 +15,8 @@ def cleanup_files_for_release(move_into_artefacts,copy_into_release,
     release_dir="release_files/",
     artefacts_dir="training_artefacts/"):
     """
-    Function that will move any files created throughout the release process and sort them into appropriate folders
+    Function that will move any files created throughout the release process and 
+    sort them into appropriate folders
     """
 
     if not os.path.exists(release_dir):
@@ -571,7 +572,9 @@ class GenerateTextReport:
 
         self.text_out.append(bucket_text)
 
-    def export_to_file(self, output_filename:str="summary.txt",
+    def export_to_file( # pylint: disable=too-many-arguments
+        self,
+        output_filename:str="summary.txt",
         move_files = False,
         model_filename = None,
         release_dir="release_files/",

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -19,7 +19,7 @@ def cleanup_files_for_release(
     artefacts_dir="training_artefacts/",
 ):
     """
-    Function that will move any files created throughout the release process and 
+    Function that will move any files created throughout the release process and
     sort them into appropriate folders
     """
 
@@ -577,11 +577,11 @@ class GenerateTextReport:
 
         self.text_out.append(bucket_text)
 
-    def export_to_file( # pylint: disable=too-many-arguments
+    def export_to_file(  # pylint: disable=too-many-arguments
         self,
-        output_filename:str="summary.txt",
-        move_files = False,
-        model_filename = None,
+        output_filename: str = "summary.txt",
+        move_files=False,
+        model_filename=None,
         release_dir="release_files/",
         artefacts_dir="training_artefacts/",
     ):

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -20,7 +20,7 @@ def generate_report(directory, attack_results, target, outfile):
         directory + attack_results, target_filename=directory + target
     )
 
-    t.export_to_file(output_filename=directory+outfile)
+    t.export_to_file(output_filename=directory+outfile,move_files=True)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -20,9 +20,9 @@ def generate_report(directory, attack_results, target, outfile):
         directory + attack_results, target_filename=directory + target
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -102,9 +102,9 @@ def generate_report(
         directory + attack_results, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -102,7 +102,7 @@ def generate_report(
         directory + attack_results, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile)
+    t.export_to_file(output_filename=directory+outfile,move_files=True)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -98,7 +98,7 @@ def generate_report(
         directory + attack_output_name, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile, model_filename=model_filename)
+    t.export_to_file(output_filename=directory+outfile,move_files=True,model_filename=model_filename)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -48,9 +48,9 @@ def generate_report(
     logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
     logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
 
-    filename = directory + target_model
-    print("Reading target model from " + filename)
-    target_model = pickle.load(open(filename, "rb"))
+    model_filename = directory + target_model
+    print("Reading target model from " + model_filename)
+    target_model = pickle.load(open(model_filename, "rb"))
 
     print("Reading training/testing data from ./" + directory)
     trainX = np.loadtxt(directory + x_train)
@@ -98,9 +98,9 @@ def generate_report(
         directory + attack_output_name, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile, model_filename=model_filename)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():


### PR DESCRIPTION
Add a function into attack_report_formatter.py which will move all of the files generated by the release process into two folders:

- training_artefacts (or similar name) - files generated in testing process (not released)
- release_files - files to be released, which will contain four files:
   - the JSON of the attack output
   - the JSON of the target
   - the model to be released
   - the final .txt recommendation