### PR TITLE
Move files for release

### DIFF
--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -5,15 +5,19 @@ Generate report for TREs from JSON file
 import json
 import os
 import pprint
-from datetime import date
 import shutil
+from datetime import date
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-def cleanup_files_for_release(move_into_artefacts,copy_into_release,
+
+def cleanup_files_for_release(
+    move_into_artefacts,
+    copy_into_release,
     release_dir="release_files/",
-    artefacts_dir="training_artefacts/"):
+    artefacts_dir="training_artefacts/",
+):
     """
     Function that will move any files created throughout the release process and 
     sort them into appropriate folders
@@ -24,13 +28,14 @@ def cleanup_files_for_release(move_into_artefacts,copy_into_release,
 
     for filename in move_into_artefacts:
         if os.path.exists(filename):
-            dest = artefacts_dir + "/" + os.path.basename(filename).split('/')[-1]
+            dest = artefacts_dir + "/" + os.path.basename(filename).split("/")[-1]
             shutil.move(filename, dest)
 
     for filename in copy_into_release:
         if os.path.exists(filename):
-            dest = release_dir + "/" + os.path.basename(filename).split('/')[-1]
+            dest = release_dir + "/" + os.path.basename(filename).split("/")[-1]
             shutil.copy(filename, dest)
+
 
 class GenerateJSONModule:
     """
@@ -511,7 +516,7 @@ class GenerateTextReport:
 
         if "model_path" in json_report.keys():
             filepath = os.path.split(os.path.abspath(self.target_json_filename))[0]
-            self.model_name_from_target = filepath + '\\' + json_report['model_path']
+            self.model_name_from_target = filepath + "\\" + json_report["model_path"]
 
         self.text_out.append(output_string)
 
@@ -578,7 +583,8 @@ class GenerateTextReport:
         move_files = False,
         model_filename = None,
         release_dir="release_files/",
-        artefacts_dir="training_artefacts/"):
+        artefacts_dir="training_artefacts/",
+    ):
         """
         Function that takes the input strings collected and combines into a neat text file
         """
@@ -599,14 +605,12 @@ class GenerateTextReport:
                 text_file.write("\n")
 
         if move_files is True:
-            move_into_artefacts = [
-                "log_roc.png"
-            ]
+            move_into_artefacts = ["log_roc.png"]
 
             copy_into_release = [
                 output_filename,
                 self.attack_json_filename,
-                self.target_json_filename
+                self.target_json_filename,
             ]
 
             if model_filename is None:
@@ -615,9 +619,5 @@ class GenerateTextReport:
                 copy_into_release.append(model_filename)
 
             cleanup_files_for_release(
-                move_into_artefacts,
-                copy_into_release,
-                release_dir,
-                artefacts_dir
-                )
-            
+                move_into_artefacts, copy_into_release, release_dir, artefacts_dir
+            )

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -572,7 +572,7 @@ class GenerateTextReport:
         self.text_out.append(bucket_text)
 
     def export_to_file(self, output_filename:str="summary.txt",
-        move_files = True,
+        move_files = False,
         model_filename = None,
         release_dir="release_files/",
         artefacts_dir="training_artefacts/"):

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -15,7 +15,8 @@ def cleanup_files_for_release(move_into_artefacts,copy_into_release,
     release_dir="release_files/",
     artefacts_dir="training_artefacts/"):
     """
-    Function that will move any files created throughout the release process and sort them into appropriate folders
+    Function that will move any files created throughout the release process and 
+    sort them into appropriate folders
     """
 
     if not os.path.exists(release_dir):
@@ -571,7 +572,9 @@ class GenerateTextReport:
 
         self.text_out.append(bucket_text)
 
-    def export_to_file(self, output_filename:str="summary.txt",
+    def export_to_file( # pylint: disable=too-many-arguments
+        self,
+        output_filename:str="summary.txt",
         move_files = False,
         model_filename = None,
         release_dir="release_files/",

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -19,7 +19,7 @@ def cleanup_files_for_release(
     artefacts_dir="training_artefacts/",
 ):
     """
-    Function that will move any files created throughout the release process and 
+    Function that will move any files created throughout the release process and
     sort them into appropriate folders
     """
 
@@ -577,11 +577,11 @@ class GenerateTextReport:
 
         self.text_out.append(bucket_text)
 
-    def export_to_file( # pylint: disable=too-many-arguments
+    def export_to_file(  # pylint: disable=too-many-arguments
         self,
-        output_filename:str="summary.txt",
-        move_files = False,
-        model_filename = None,
+        output_filename: str = "summary.txt",
+        move_files=False,
+        model_filename=None,
         release_dir="release_files/",
         artefacts_dir="training_artefacts/",
     ):

--- a/example_notebooks/user_stories/user_story_1/user_story_1_researcher.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_researcher.py
@@ -1,0 +1,128 @@
+"""
+User story 1 as researcher
+"""
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+from aisdc.attacks.target import Target  # pylint: disable=import-error
+from aisdc.safemodel.classifiers import (
+    SafeDecisionTreeClassifier,  # pylint: disable=import-error
+)
+
+
+def main():
+    """
+    Create and train a model to be released
+    """
+    directory = "training_artefacts/"
+    print("Creating directory for training artefacts")
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    print()
+    print("Acting as researcher...")
+    print()
+
+    filename = "user_stories_resources/dataset_26_nursery.csv"
+    print("Reading data from " + filename)
+    data = pd.read_csv(filename)
+
+    print()
+
+    y = np.asarray(data["class"])
+    x = np.asarray(data.drop(columns=["class"], inplace=False))
+
+    n_features = np.shape(x)[1]
+    indices: list[list[int]] = [
+        [0, 1, 2],  # parents
+        [3, 4, 5, 6, 7],  # has_nurs
+        [8, 9, 10, 11],  # form
+        [12, 13, 14, 15],  # children
+        [16, 17, 18],  # housing
+        [19, 20],  # finance
+        [21, 22, 23],  # social
+        [24, 25, 26],  # health
+    ]
+
+    # [Researcher] Split into training and test sets
+    # target model train / test split - these are strings
+    (
+        x_train_orig,
+        x_test_orig,
+        y_train_orig,
+        y_test_orig,
+    ) = train_test_split(
+        x,
+        y,
+        test_size=0.5,
+        stratify=y,
+        shuffle=True,
+    )
+
+    # [Researcher] Preprocess dataset
+    # one-hot encoding of features and integer encoding of labels
+    label_enc = LabelEncoder()
+    feature_enc = OneHotEncoder()
+    x_train = feature_enc.fit_transform(x_train_orig).toarray()
+    y_train = label_enc.fit_transform(y_train_orig)
+    x_test = feature_enc.transform(x_test_orig).toarray()
+    y_test = label_enc.transform(y_test_orig)
+
+    logging.getLogger("attack-reps").setLevel(logging.WARNING)
+    logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
+    logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
+
+    # Build a model
+    model = SafeDecisionTreeClassifier(random_state=1)
+    model.fit(x_train, y_train)
+    msg, disclosive = model.preliminary_check()
+
+    # Wrap the model and data in a Target object
+    target = Target(model=model)
+    target.name = "nursery"
+    target.add_processed_data(x_train, y_train, x_test, y_test)
+    target.add_raw_data(x, y, x_train_orig, y_train_orig, x_test_orig, y_test_orig)
+    for i in range(n_features):
+        target.add_feature(data.columns[i], indices[i], "onehot")
+
+    logging.info("Dataset: %s", target.name)
+    logging.info("Features: %s", target.features)
+    logging.info("x_train shape = %s", np.shape(target.x_train))
+    logging.info("y_train shape = %s", np.shape(target.y_train))
+    logging.info("x_test shape = %s", np.shape(target.x_test))
+    logging.info("y_test shape = %s", np.shape(target.y_test))
+
+    # Researcher can check for themselves whether their model passes individual disclosure checks
+    SAVE_PATH = directory
+
+    # check direct method
+    print("==========> first running attacks explicitly via run_attack()")
+    results_filename = os.path.normpath(f"{SAVE_PATH}/direct_results.json")
+    for attack_name in ["worst_case", "attribute", "lira"]:
+        print(f"===> running {attack_name} attack directly")
+        metadata = model.run_attack(target, attack_name, results_filename)
+        logging.info("metadata is:")
+        for key, val in metadata.items():
+            if isinstance(val, dict):
+                logging.info(" %s ", key)
+                for key1, val2 in val.items():
+                    logging.info("  %s : %s", key1, val2)
+            else:
+                logging.info(" %s : %s", key, val)
+
+    # when researcher is satisfied the call request release()
+    # if they pass in the target model object the code will automatically run checks for the TRE staff
+    print("===> now running attacks implicitly via request_release()")
+    model.request_release(path=SAVE_PATH, ext="pkl", target=target)
+
+    print(f"Please see the files generated in: {SAVE_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -1,0 +1,94 @@
+"""
+User story 1 as TRE
+"""
+import argparse
+
+from aisdc.attacks.attack_report_formatter import GenerateTextReport
+
+
+def generate_report(directory, attack_results, target, outfile):
+    """
+    Generate report based on target model
+    """
+
+    print()
+    print("Acting as TRE...")
+    print()
+
+    t = GenerateTextReport()
+    t.process_attack_target_json(
+        directory + attack_results, target_filename=directory + target
+    )
+
+    t.export_to_file(output_filename=outfile)
+
+    print("Results written to " + outfile)
+
+
+def main():
+    """main method to parse arguments and then invoke report generstion"""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a risk report after request_release() has been called by researcher"
+        )
+    )
+
+    parser.add_argument(
+        "--training_artefacts_directory",
+        type=str,
+        action="store",
+        dest="training_artefacts_directory",
+        required=False,
+        default="training_artefacts/",
+        help=(
+            "Folder containing training artefacts produced by researcher. Default = %(default)s."
+        ),
+    )
+
+    parser.add_argument(
+        "--attack_results",
+        type=str,
+        action="store",
+        dest="attack_results",
+        required=False,
+        default="attack_results.json",
+        help=("Filename for the saved JSON attack output. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--target_results",
+        type=str,
+        action="store",
+        dest="target_results",
+        required=False,
+        default="target.json",
+        help=("Filename for the saved JSON model output. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--outfile",
+        type=str,
+        action="store",
+        dest="outfile",
+        required=False,
+        default="summary.txt",
+        help=(
+            "Filename for the final results to be written to. Default = %(default)s."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    try:
+        generate_report(
+            args.training_artefacts_directory,
+            args.attack_results,
+            args.target_results,
+            args.outfile,
+        )
+    except AttributeError as e:  # pragma:no cover
+        print("Invalid command. Try --help to get more details" f"error mesge is {e}")
+
+
+if __name__ == "__main__":  # pragma:no cover
+    main()

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -20,7 +20,7 @@ def generate_report(directory, attack_results, target, outfile):
         directory + attack_results, target_filename=directory + target
     )
 
-    t.export_to_file(output_filename=directory+outfile)
+    t.export_to_file(output_filename=directory+outfile,move_files=True)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -20,9 +20,9 @@ def generate_report(directory, attack_results, target, outfile):
         directory + attack_results, target_filename=directory + target
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
+++ b/example_notebooks/user_stories/user_story_1/user_story_1_tre.py
@@ -20,9 +20,9 @@ def generate_report(directory, attack_results, target, outfile):
         directory + attack_results, target_filename=directory + target
     )
 
-    t.export_to_file(output_filename=directory+outfile,move_files=True)
+    t.export_to_file(output_filename=directory + outfile, move_files=True)
 
-    print("Results written to " + directory+outfile)
+    print("Results written to " + directory + outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_2/user_story_2_researcher.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_researcher.py
@@ -1,0 +1,117 @@
+"""
+User story 2 (best case) as researcher
+"""
+
+import logging
+import os
+import pickle
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+from aisdc.attacks.target import Target  # pylint: disable=import-error
+from aisdc.safemodel.classifiers import (
+    SafeDecisionTreeClassifier,  # pylint: disable=import-error
+)
+
+
+def main():
+    """
+    Create and train a model to be released
+    """
+    directory = "training_artefacts/"
+    print("Creating directory for training artefacts")
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    print()
+    print("Acting as researcher...")
+    print()
+
+    filename = "user_stories_resources/dataset_26_nursery.csv"
+    print("Reading data from " + filename)
+    data = pd.read_csv(filename)
+
+    print()
+
+    y = np.asarray(data["class"])
+    x = np.asarray(data.drop(columns=["class"], inplace=False))
+
+    n_features = np.shape(x)[1]
+    indices: list[list[int]] = [
+        [0, 1, 2],  # parents
+        [3, 4, 5, 6, 7],  # has_nurs
+        [8, 9, 10, 11],  # form
+        [12, 13, 14, 15],  # children
+        [16, 17, 18],  # housing
+        [19, 20],  # finance
+        [21, 22, 23],  # social
+        [24, 25, 26],  # health
+    ]
+
+    row_indices = np.arange(np.shape(x)[0])
+
+    # [Researcher] Split into training and test sets
+    # target model train / test split - these are strings
+    (
+        x_train_orig,
+        x_test_orig,
+        y_train_orig,
+        y_test_orig,
+        indices_train,
+        indices_test,
+    ) = train_test_split(
+        x,
+        y,
+        row_indices,
+        test_size=0.5,
+        stratify=y,
+        shuffle=True,
+    )
+
+    # Preprocess dataset
+    # one-hot encoding of features and integer encoding of labels
+    label_enc = LabelEncoder()
+    feature_enc = OneHotEncoder()
+    x_train = feature_enc.fit_transform(x_train_orig).toarray()
+    y_train = label_enc.fit_transform(y_train_orig)
+    x_test = feature_enc.transform(x_test_orig).toarray()
+    y_test = label_enc.transform(y_test_orig)
+
+    logging.getLogger("attack-reps").setLevel(logging.WARNING)
+    logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
+    logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
+
+    # Build a model and request its release
+    model = SafeDecisionTreeClassifier(random_state=1)
+    model.fit(x_train, y_train)
+    model.request_release(path=directory, ext="pkl")
+
+    # Wrap the model and data in a Target object
+    target = Target(model=model)
+    target.name = "nursery"
+    target.add_processed_data(x_train, y_train, x_test, y_test)
+    target.add_raw_data(x, y, x_train_orig, y_train_orig, x_test_orig, y_test_orig)
+    for i in range(n_features):
+        target.add_feature(data.columns[i], indices[i], "onehot")
+
+    # NOTE: we assume here that the researcher does not use the target.save() function
+    # and instead provides only the model and the list of indices which have been used to split the dataset
+
+    print("Saving training/testing indices to ./" + directory)
+    np.savetxt(directory + "indices_train.txt", indices_train, fmt="%d")
+    np.savetxt(directory + "indices_test.txt", indices_test, fmt="%d")
+
+    logging.info("Dataset: %s", target.name)
+    logging.info("Features: %s", target.features)
+    logging.info("x_train shape = %s", np.shape(target.x_train))
+    logging.info("y_train shape = %s", np.shape(target.y_train))
+    logging.info("x_test shape = %s", np.shape(target.x_test))
+    logging.info("y_test shape = %s", np.shape(target.y_test))
+
+
+if __name__ == "__main__":
+    main()

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -1,0 +1,209 @@
+"""
+User story 2 (best case) as TRE
+"""
+
+import argparse
+import logging
+import os
+import pickle
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+from aisdc.attacks.attack_report_formatter import GenerateTextReport
+from aisdc.attacks.target import Target  # pylint: disable=import-error
+
+
+def generate_report(
+    directory,
+    target_model,
+    train_indices,
+    test_indices,
+    attack_results,
+    target_filename,
+    outfile,
+):
+    """
+    Generate report based on target model
+    """
+
+    print()
+    print("Acting as TRE...")
+    print(
+        "(when instructions on how to recreate the dataset have been provided by the researcher)"
+    )
+    print()
+
+    filename = directory + target_model
+    print("Reading target model from " + filename)
+    target_model = pickle.load(open(filename, "rb"))
+
+    print("Reading training/testing indices from ./" + directory)
+    indices_train = np.loadtxt(directory + train_indices)
+    indices_test = np.loadtxt(directory + test_indices)
+
+    filename = "user_stories_resources/dataset_26_nursery.csv"
+    print("Reading data from " + filename)
+    data = pd.read_csv(filename)
+
+    print()
+
+    print(data.head())
+    print(indices_test[:10])
+    print(indices_train[:10])
+
+    y = np.asarray(data["class"])
+    x = np.asarray(data.drop(columns=["class"], inplace=False))
+
+    n_features = np.shape(x)[1]
+    indices: list[list[int]] = [
+        [0, 1, 2],  # parents
+        [3, 4, 5, 6, 7],  # has_nurs
+        [8, 9, 10, 11],  # form
+        [12, 13, 14, 15],  # children
+        [16, 17, 18],  # housing
+        [19, 20],  # finance
+        [21, 22, 23],  # social
+        [24, 25, 26],  # health
+    ]
+
+    x_train_orig = np.asarray([x[int(i)] for i in indices_train])
+    y_train_orig = np.asarray([y[int(i)] for i in indices_train])
+    x_test_orig = np.asarray([x[int(i)] for i in indices_test])
+    y_test_orig = np.asarray([y[int(i)] for i in indices_test])
+
+    # Preprocess dataset
+    # one-hot encoding of features and integer encoding of labels
+    label_enc = LabelEncoder()
+    feature_enc = OneHotEncoder()
+    x_train = feature_enc.fit_transform(x_train_orig).toarray()
+    y_train = label_enc.fit_transform(y_train_orig)
+    x_test = feature_enc.transform(x_test_orig).toarray()
+    y_test = label_enc.transform(y_test_orig)
+
+    # Wrap the model and data in a Target object
+    target = Target(model=target_model)
+    target.add_processed_data(x_train, y_train, x_test, y_test)
+    target.add_raw_data(x, y, x_train_orig, y_train_orig, x_test_orig, y_test_orig)
+    for i in range(n_features):
+        target.add_feature(data.columns[i], indices[i], "onehot")
+
+    SAVE_PATH = directory
+
+    # TRE calls request_release()
+    print("===> now running attacks implicitly via request_release()")
+    target_model.request_release(path=SAVE_PATH, ext="pkl", target=target)
+
+    print(f"Please see the files generated in: {SAVE_PATH}")
+
+    t = GenerateTextReport()
+    t.process_attack_target_json(
+        directory + attack_results, target_filename=directory + target_filename
+    )
+
+    t.export_to_file(output_filename=outfile)
+
+    print("Results written to " + outfile)
+
+
+def main():
+    """main method to parse arguments and then invoke report generation"""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a risk report after request_release() has been called by researcher"
+        )
+    )
+
+    parser.add_argument(
+        "--training_artefacts_directory",
+        type=str,
+        action="store",
+        dest="training_artefacts_directory",
+        required=False,
+        default="training_artefacts/",
+        help=(
+            "Folder containing training artefacts produced by researcher. Default = %(default)s."
+        ),
+    )
+
+    parser.add_argument(
+        "--target_model",
+        type=str,
+        action="store",
+        dest="target_model",
+        required=False,
+        default="/model.pkl",
+        help=("Filename of target model. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--train_indices",
+        type=str,
+        action="store",
+        dest="train_indices",
+        required=False,
+        default="indices_train.txt",
+        help=("Filename for the saved training indices. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--test_indices",
+        type=str,
+        action="store",
+        dest="test_indices",
+        required=False,
+        default="indices_test.txt",
+        help=("Filename for the saved testing indices. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--attack_results",
+        type=str,
+        action="store",
+        dest="attack_results",
+        required=False,
+        default="attack_results.json",
+        help=("Filename for the saved JSON attack output. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--target_results",
+        type=str,
+        action="store",
+        dest="target_results",
+        required=False,
+        default="target.json",
+        help=("Filename for the saved JSON model output. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--outfile",
+        type=str,
+        action="store",
+        dest="outfile",
+        required=False,
+        default="summary.txt",
+        help=(
+            "Filename for the final results to be written to. Default = %(default)s."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    try:
+        generate_report(
+            args.training_artefacts_directory,
+            args.target_model,
+            args.train_indices,
+            args.test_indices,
+            args.attack_results,
+            args.target_results,
+            args.outfile,
+        )
+    except AttributeError as e:  # pragma:no cover
+        print("Invalid command. Try --help to get more details" f"error mesge is {e}")
+
+
+if __name__ == "__main__":  # pragma:no cover
+    main()

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -102,9 +102,9 @@ def generate_report(
         directory + attack_results, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -102,9 +102,9 @@ def generate_report(
         directory + attack_results, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile,move_files=True)
+    t.export_to_file(output_filename=directory + outfile, move_files=True)
 
-    print("Results written to " + directory+outfile)
+    print("Results written to " + directory + outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
+++ b/example_notebooks/user_stories/user_story_2/user_story_2_tre.py
@@ -102,7 +102,7 @@ def generate_report(
         directory + attack_results, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile)
+    t.export_to_file(output_filename=directory+outfile,move_files=True)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_3/user_story_3_researcher.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_researcher.py
@@ -1,0 +1,78 @@
+"""
+Example of researcher just using `standard' dsklearn algorithms
+and submitting saved model and their train/test datasets
+@Yola Jones 2023, tweaked by @Jim Smith
+"""
+import os
+import pickle
+
+import numpy as np
+import pandas as pd
+from scipy.io.arff import loadarff
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+print()
+print("Acting as researcher...")
+print()
+
+directory = "training_artefacts/"
+print("Creating directory for training artefacts")
+
+if not os.path.exists(directory):
+    os.makedirs(directory)
+
+filename = "user_stories_resources/dataset_26_nursery.csv"
+print("Reading data from " + filename)
+data = pd.read_csv(filename)
+
+print()
+
+target_encoder = LabelEncoder()
+target_vals = target_encoder.fit_transform(data["class"].values)
+target_dataframe = pd.DataFrame({"class": target_vals})
+data = data.drop(columns=["class"], inplace=False)
+
+feature_encoder = OneHotEncoder()
+x_encoded = feature_encoder.fit_transform(data).toarray()
+feature_dataframe = pd.DataFrame(
+    x_encoded, columns=feature_encoder.get_feature_names_out()
+)
+
+trainX, testX, trainy, testy = train_test_split(
+    feature_dataframe.values,
+    target_dataframe.values.flatten(),
+    test_size=0.7,
+    random_state=42,
+)
+
+print("Saving training/testing data to ./" + directory)
+np.savetxt(directory + "trainX.txt", trainX, fmt="%d")
+np.savetxt(directory + "trainy.txt", trainy, fmt="%d")
+np.savetxt(directory + "testX.txt", testX, fmt="%d")
+np.savetxt(directory + "testy.txt", testy, fmt="%d")
+
+# These hyperparameters lead to a dangerously disclosive trained model
+DISCLOSIVE_HYPERPARAMETERS = {}
+DISCLOSIVE_HYPERPARAMETERS["min_samples_split"] = 2
+DISCLOSIVE_HYPERPARAMETERS["min_samples_leaf"] = 1
+DISCLOSIVE_HYPERPARAMETERS["max_depth"] = None
+DISCLOSIVE_HYPERPARAMETERS["bootstrap"] = False
+
+print(
+    "Training disclosive model with the following hyperparameters: "
+    + str(DISCLOSIVE_HYPERPARAMETERS)
+)
+target_model = RandomForestClassifier(**DISCLOSIVE_HYPERPARAMETERS)
+target_model.fit(trainX, trainy)
+
+train_acc = accuracy_score(trainy, target_model.predict(trainX))
+test_acc = accuracy_score(testy, target_model.predict(testX))
+print(f"Training accuracy on disclosive model: {train_acc:.2f}")
+print(f"Testing accuracy on disclosive model: {test_acc:.2f}")
+
+filename = directory + "/disclosive_random_forest.sav"
+print("Saving disclosive model to " + filename)
+pickle.dump(target_model, open(filename, "wb"))

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -98,7 +98,7 @@ def generate_report(
         directory + attack_output_name, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile, model_filename=model_filename)
+    t.export_to_file(output_filename=directory+outfile,move_files=True,model_filename=model_filename)
 
     print("Results written to " + directory+outfile)
 

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -1,0 +1,229 @@
+"""
+User story 3 as TRE
+"""
+
+import argparse
+import json
+import logging
+import os
+import pickle
+
+import numpy as np
+
+from aisdc.attacks.attack_report_formatter import GenerateJSONModule, GenerateTextReport
+from aisdc.attacks.likelihood_attack import LIRAAttack
+from aisdc.attacks.target import Target  # pylint: disable=import-error
+from aisdc.attacks.worst_case_attack import WorstCaseAttack
+
+
+def generate_report(
+    directory,
+    target_model,
+    x_train,
+    y_train,
+    x_test,
+    y_test,
+    attack_output_name,
+    target_filename,
+    outfile,
+):
+    """
+    Generate report based on target model
+    """
+
+    print()
+    print("Acting as TRE...")
+    print()
+
+    directory = "training_artefacts/"
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__file__)
+
+    # Suppress messages from AI-SDC -- comment out these lines to see all the aisdc logging statements
+    logging.getLogger("attack-reps").setLevel(logging.WARNING)
+    logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
+    logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
+
+    filename = directory + target_model
+    print("Reading target model from " + filename)
+    target_model = pickle.load(open(filename, "rb"))
+
+    print("Reading training/testing data from ./" + directory)
+    trainX = np.loadtxt(directory + x_train)
+    trainy = np.loadtxt(directory + y_train)
+    testX = np.loadtxt(directory + x_test)
+    testy = np.loadtxt(directory + y_test)
+
+    g = GenerateJSONModule(directory + attack_output_name)
+    target = Target(model=target_model)
+    # Wrap the training and test data into the Data object
+    target.add_processed_data(trainX, trainy, testX, testy)
+
+    # Run the attack
+    wca = WorstCaseAttack(
+        n_dummy_reps=10, report_name=directory + "/disclosive_model_raw_output"
+    )
+    wca.attack(target)
+
+    json_out = wca.make_report(g)
+
+    lira_config = {
+        "training_data_filename": "train_data.csv",
+        "test_data_filename": "test_data.csv",
+        "training_preds_filename": "train_preds.csv",
+        "test_preds_filename": "test_preds.csv",
+        "target_model": ["sklearn.ensemble", "RandomForestClassifier"],
+        "target_model_hyp": {"min_samples_split": 2, "min_samples_leaf": 1},
+    }
+
+    with open(directory + "lira_config.json", "w", encoding="utf-8") as f:
+        f.write(json.dumps(lira_config))
+
+    lira_attack_obj = LIRAAttack(
+        n_shadow_models=100,
+        attack_config_json_file_name=directory + "lira_config.json",
+    )
+
+    lira_attack_obj.attack(target)
+    output = lira_attack_obj.make_report(g)
+
+    target.save(directory + "/target/")
+
+    t = GenerateTextReport()
+    t.process_attack_target_json(
+        directory + attack_output_name, target_filename=directory + target_filename
+    )
+
+    t.export_to_file(output_filename=outfile)
+
+    print("Results written to " + outfile)
+
+
+def main():
+    """main method to parse arguments and then invoke report generation"""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a risk report after request_release() has been called by researcher"
+        )
+    )
+
+    parser.add_argument(
+        "--training_artefacts_directory",
+        type=str,
+        action="store",
+        dest="training_artefacts_directory",
+        required=False,
+        default="training_artefacts/",
+        help=(
+            "Folder containing training artefacts produced by researcher. Default = %(default)s."
+        ),
+    )
+
+    parser.add_argument(
+        "--target_model",
+        type=str,
+        action="store",
+        dest="target_model",
+        required=False,
+        default="/disclosive_random_forest.sav",
+        help=("Filename of target model. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--x_train_path",
+        type=str,
+        action="store",
+        dest="x_train_path",
+        required=False,
+        default="trainX.txt",
+        help=("Filename for the saved training data. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--y_train_path",
+        type=str,
+        action="store",
+        dest="y_train_path",
+        required=False,
+        default="trainy.txt",
+        help=("Filename for the saved training labels. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--x_test_path",
+        type=str,
+        action="store",
+        dest="x_test_path",
+        required=False,
+        default="testX.txt",
+        help=("Filename for the saved testiing data. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--y_test_path",
+        type=str,
+        action="store",
+        dest="y_test_path",
+        required=False,
+        default="testy.txt",
+        help=("Filename for the saved testing labels. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--attack_output_name",
+        type=str,
+        action="store",
+        dest="attack_output_name",
+        required=False,
+        default="/attack_output.json",
+        help=(
+            "Filename for the attack JSON output to be written to. Default = %(default)s."
+        ),
+    )
+
+    parser.add_argument(
+        "--target_results",
+        type=str,
+        action="store",
+        dest="target_results",
+        required=False,
+        default="/target/target.json",
+        help=("Filename for the saved JSON model output. Default = %(default)s."),
+    )
+
+    parser.add_argument(
+        "--outfile",
+        type=str,
+        action="store",
+        dest="outfile",
+        required=False,
+        default="summary.txt",
+        help=(
+            "Filename for the final results to be written to. Default = %(default)s."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    try:
+        generate_report(
+            args.training_artefacts_directory,
+            args.target_model,
+            args.x_train_path,
+            args.y_train_path,
+            args.x_test_path,
+            args.y_test_path,
+            args.attack_output_name,
+            args.target_results,
+            args.outfile,
+        )
+    except AttributeError as e:  # pragma:no cover
+        print("Invalid command. Try --help to get more details" f"error mesge is {e}")
+
+
+if __name__ == "__main__":  # pragma:no cover
+    main()

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -98,9 +98,13 @@ def generate_report(
         directory + attack_output_name, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=directory+outfile,move_files=True,model_filename=model_filename)
+    t.export_to_file(
+        output_filename=directory + outfile,
+        move_files=True,
+        model_filename=model_filename,
+    )
 
-    print("Results written to " + directory+outfile)
+    print("Results written to " + directory + outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
+++ b/example_notebooks/user_stories/user_story_3/user_story_3_tre.py
@@ -48,9 +48,9 @@ def generate_report(
     logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
     logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
 
-    filename = directory + target_model
-    print("Reading target model from " + filename)
-    target_model = pickle.load(open(filename, "rb"))
+    model_filename = directory + target_model
+    print("Reading target model from " + model_filename)
+    target_model = pickle.load(open(model_filename, "rb"))
 
     print("Reading training/testing data from ./" + directory)
     trainX = np.loadtxt(directory + x_train)
@@ -98,9 +98,9 @@ def generate_report(
         directory + attack_output_name, target_filename=directory + target_filename
     )
 
-    t.export_to_file(output_filename=outfile)
+    t.export_to_file(output_filename=directory+outfile, model_filename=model_filename)
 
-    print("Results written to " + outfile)
+    print("Results written to " + directory+outfile)
 
 
 def main():

--- a/example_notebooks/user_stories/user_story_7/user_story_7_researcher.py
+++ b/example_notebooks/user_stories/user_story_7/user_story_7_researcher.py
@@ -1,0 +1,102 @@
+"""
+User story 7 (researcher)
+"""
+import logging
+import os
+import pickle
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+from aisdc.attacks.target import Target  # pylint: disable=import-error
+from aisdc.safemodel.classifiers import (
+    SafeDecisionTreeClassifier,  # pylint: disable=import-error
+)
+
+
+def main():
+    """
+    Create and train model to be released
+    """
+    directory = "training_artefacts/"
+    print("Creating directory for training artefacts")
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    print()
+    print("Acting as researcher...")
+    print()
+
+    filename = "user_stories_resources/dataset_26_nursery.csv"
+    print("Reading data from " + filename)
+    data = pd.read_csv(filename)
+
+    print()
+
+    y = np.asarray(data["class"])
+    x = np.asarray(data.drop(columns=["class"], inplace=False))
+
+    n_features = np.shape(x)[1]
+    indices: list[list[int]] = [
+        [0, 1, 2],  # parents
+        [3, 4, 5, 6, 7],  # has_nurs
+        [8, 9, 10, 11],  # form
+        [12, 13, 14, 15],  # children
+        [16, 17, 18],  # housing
+        [19, 20],  # finance
+        [21, 22, 23],  # social
+        [24, 25, 26],  # health
+    ]
+
+    # Split into training and test sets
+    # target model train / test split - these are strings
+    (x_train_orig, x_test_orig, y_train_orig, y_test_orig) = train_test_split(
+        x,
+        y,
+        test_size=0.5,
+        stratify=y,
+        shuffle=True,
+    )
+
+    # Preprocess dataset
+    # one-hot encoding of features and integer encoding of labels
+    label_enc = LabelEncoder()
+    feature_enc = OneHotEncoder()
+    x_train = feature_enc.fit_transform(x_train_orig).toarray()
+    y_train = label_enc.fit_transform(y_train_orig)
+    x_test = feature_enc.transform(x_test_orig).toarray()
+    y_test = label_enc.transform(y_test_orig)
+
+    logging.getLogger("attack-reps").setLevel(logging.WARNING)
+    logging.getLogger("prep-attack-data").setLevel(logging.WARNING)
+    logging.getLogger("attack-from-preds").setLevel(logging.WARNING)
+
+    # Build a model
+    model = SafeDecisionTreeClassifier(random_state=1)
+    model.fit(x_train, y_train)
+    model.request_release(path=directory, ext="pkl")
+
+    # Wrap the model and data in a Target object
+    target = Target(model=model)
+    target.name = "nursery"
+    target.add_processed_data(x_train, y_train, x_test, y_test)
+    target.add_raw_data(x, y, x_train_orig, y_train_orig, x_test_orig, y_test_orig)
+    for i in range(n_features):
+        target.add_feature(data.columns[i], indices[i], "onehot")
+
+    # NOTE: we assume here that the researcher does not use the target.save() function
+    # and instead provides only the model
+
+    logging.info("Dataset: %s", target.name)
+    logging.info("Features: %s", target.features)
+    logging.info("x_train shape = %s", np.shape(target.x_train))
+    logging.info("y_train shape = %s", np.shape(target.y_train))
+    logging.info("x_test shape = %s", np.shape(target.x_test))
+    logging.info("y_test shape = %s", np.shape(target.y_test))
+
+
+if __name__ == "__main__":
+    main()

--- a/example_notebooks/user_stories/user_story_7/user_story_7_tre.py
+++ b/example_notebooks/user_stories/user_story_7/user_story_7_tre.py
@@ -1,0 +1,65 @@
+"""
+User story 7 as TRE
+"""
+
+import argparse
+import pickle
+
+
+def generate_report(directory, target_model_filepath):
+    """main method to parse arguments and then invoke report generation"""
+    print()
+    print("Acting as TRE...")
+    print(
+        "(when researcher has provided NO INSTRUCTIONS on how to recreate the dataset)"
+    )
+    print()
+
+    filename = directory + target_model_filepath
+    print("Reading target model from " + filename)
+    _ = pickle.load(open(filename, "rb"))
+
+    print("Attacks cannot be run since the original dataset cannot be recreated")
+    print("AISDC cannot provide any help to TRE")
+
+
+def main():
+    """main method to parse arguments and then invoke report generation"""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a risk report after request_release() has been called by researcher"
+        )
+    )
+
+    parser.add_argument(
+        "--training_artefacts_directory",
+        type=str,
+        action="store",
+        dest="training_artefacts_directory",
+        required=False,
+        default="training_artefacts/",
+        help=(
+            "Folder containing training artefacts produced by researcher. Default = %(default)s."
+        ),
+    )
+
+    parser.add_argument(
+        "--target_model",
+        type=str,
+        action="store",
+        dest="target_model",
+        required=False,
+        default="/model.pkl",
+        help=("Filename of target model. Default = %(default)s."),
+    )
+
+    args = parser.parse_args()
+
+    try:
+        generate_report(args.training_artefacts_directory, args.target_model)
+    except AttributeError as e:  # pragma:no cover
+        print("Invalid command. Try --help to get more details" f"error mesge is {e}")
+
+
+if __name__ == "__main__":  # pragma:no cover
+    main()


### PR DESCRIPTION
Add a function into attack_report_formatter.py which will move all of the files generated by the release process into two folders:

- training_artefacts (or similar name) - files generated in testing process (not released)
- release_files - files to be released, which will contain four files:
- the JSON of the attack output
- the JSON of the target
- the model to be released
- the final .txt recommendation