### PR TITLE
Fixing attack_report_formatter bug

### DIFF
--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -203,7 +203,9 @@ class FinalRecommendationModule(
                         instance = self.report[k]["attack_experiment_logger"][
                             "attack_instance_logger"
                         ][i]
-                        if instance["P_HIGHER_AUC"] < p_val_thresh:
+
+                        auc_key = 'P_HIGHER_AUC'
+                        if auc_key in instance.keys() and instance[auc_key] < p_val_thresh:
                             stat_sig_auc.append(instance["AUC"])
 
                     n_instances = len(

--- a/aisdc/attacks/attack_report_formatter.py
+++ b/aisdc/attacks/attack_report_formatter.py
@@ -204,8 +204,11 @@ class FinalRecommendationModule(
                             "attack_instance_logger"
                         ][i]
 
-                        auc_key = 'P_HIGHER_AUC'
-                        if auc_key in instance.keys() and instance[auc_key] < p_val_thresh:
+                        auc_key = "P_HIGHER_AUC"
+                        if (
+                            auc_key in instance.keys()
+                            and instance[auc_key] < p_val_thresh
+                        ):
                             stat_sig_auc.append(instance["AUC"])
 
                     n_instances = len(


### PR DESCRIPTION
A minor bug has been introduced in the code which prevents the user stories being run, related to there not being a 'P_HIGHER_AUC' key in each instance of the 'attack_experiment_logger'

This PR fixes this