### PR TITLE
feat: save and reuse trained shadow models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Changes:
 *   Add example running attacks with only csv probabilities supplied ([#353](https://github.com/AI-SDC/SACRO-ML/pull/353))
+*   Add PDF report generation for structural attacks ([#355](https://github.com/AI-SDC/SACRO-ML/pull/355))
+*   Save and reuse trained shadow models ([#357](https://github.com/AI-SDC/SACRO-ML/pull/357))
 
 ## Version 1.4.0 (Jul 4, 2025)
 

--- a/sacroml/attacks/attack.py
+++ b/sacroml/attacks/attack.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import importlib
 import inspect
 import logging
 import os
-import pickle
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any
 
-import numpy as np
 from fpdf import FPDF
 
 from sacroml.attacks import report
@@ -126,44 +122,3 @@ class Attack(ABC):
         for key in self._get_param_names():
             out[key] = getattr(self, key)
         return out
-
-    def save_shadow_model(
-        self, idx: int, model: Any, indices_train: np.ndarray, indices_test: np.ndarray
-    ) -> None:
-        """Save a trained shadow model."""
-        path: str = os.path.normpath(f"{self.output_dir}/shadow_models/{idx}")
-        os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, "model.pkl"), "wb") as f:
-            pickle.dump(model, f)
-        with open(os.path.join(path, "indices_train.pkl"), "wb") as f:
-            pickle.dump(indices_train, f)
-        with open(os.path.join(path, "indices_test.pkl"), "wb") as f:
-            pickle.dump(indices_test, f)
-
-    def get_shadow_model(self, idx: int) -> tuple[Any, np.ndarray, np.ndarray]:
-        """Return a shadow model and indices previously saved."""
-        path: str = os.path.normpath(f"{self.output_dir}/shadow_models/{idx}")
-        with open(os.path.join(path, "model.pkl"), "rb") as f:
-            model = pickle.load(f)
-        with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
-            indices_train = pickle.load(f)
-        with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
-            indices_test = pickle.load(f)
-        return model, indices_train, indices_test
-
-    def get_n_shadow_models(self) -> int:
-        """Return the number shadow models saved."""
-        path: str = os.path.normpath(f"{self.output_dir}/shadow_models")
-        count: int = 0
-        for item in os.listdir(path):
-            item_path = os.path.join(path, item)
-            if os.path.isdir(item_path):
-                count += 1
-        return count
-
-
-def get_class_by_name(class_path: str):
-    """Return a class given its name."""
-    module_path, class_name = class_path.rsplit(".", 1)
-    module = importlib.import_module(module_path)
-    return getattr(module, class_name)

--- a/sacroml/attacks/attack.py
+++ b/sacroml/attacks/attack.py
@@ -6,10 +6,13 @@ import importlib
 import inspect
 import logging
 import os
+import pickle
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any
 
+import numpy as np
 from fpdf import FPDF
 
 from sacroml.attacks import report
@@ -123,6 +126,40 @@ class Attack(ABC):
         for key in self._get_param_names():
             out[key] = getattr(self, key)
         return out
+
+    def save_shadow_model(
+        self, idx: int, model: Any, indices_train: np.ndarray, indices_test: np.ndarray
+    ) -> None:
+        """Save a trained shadow model."""
+        path: str = os.path.normpath(f"{self.output_dir}/shadow_models/{idx}")
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "model.pkl"), "wb") as f:
+            pickle.dump(model, f)
+        with open(os.path.join(path, "indices_train.pkl"), "wb") as f:
+            pickle.dump(indices_train, f)
+        with open(os.path.join(path, "indices_test.pkl"), "wb") as f:
+            pickle.dump(indices_test, f)
+
+    def get_shadow_model(self, idx: int) -> tuple[Any, np.ndarray, np.ndarray]:
+        """Return a shadow model and indices previously saved."""
+        path: str = os.path.normpath(f"{self.output_dir}/shadow_models/{idx}")
+        with open(os.path.join(path, "model.pkl"), "rb") as f:
+            model = pickle.load(f)
+        with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
+            indices_train = pickle.load(f)
+        with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
+            indices_test = pickle.load(f)
+        return model, indices_train, indices_test
+
+    def get_n_shadow_models(self) -> int:
+        """Return the number shadow models saved."""
+        path: str = os.path.normpath(f"{self.output_dir}/shadow_models")
+        count: int = 0
+        for item in os.listdir(path):
+            item_path = os.path.join(path, item)
+            if os.path.isdir(item_path):
+                count += 1
+        return count
 
 
 def get_class_by_name(class_path: str):

--- a/sacroml/attacks/attack.py
+++ b/sacroml/attacks/attack.py
@@ -38,6 +38,10 @@ class Attack(ABC):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
 
+        # Create folder for saving trained shadow models
+        self.shadow_path: str = os.path.normpath(f"{self.output_dir}/shadow_models")
+        os.makedirs(self.shadow_path, exist_ok=True)
+
     @classmethod
     @abstractmethod
     def attackable(cls, target: Target) -> bool:

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -34,7 +34,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 EPS: float = 1e-16  # Used to avoid numerical issues
-MODES: list[str] = ["offline", "offline-carlini", "online-carlini"]
 
 
 class LIRAAttack(Attack):

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -269,12 +269,12 @@ class LIRAAttack(Attack):
             Dictionary of confidences when not in the training set.
             Dictionary of confidences when in the training set.
         """
-        logger.info("Getting shadow model signals")
-
         n_shadow_models: int = utils.get_n_shadow_models(self.output_dir)
         n_combined: int = combined_x_train.shape[0]
         out_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
         in_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
+
+        logger.info("Getting signals from %d shadow models", n_shadow_models)
 
         for model_idx in range(n_shadow_models):
             # load shadow model

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -1,4 +1,19 @@
-"""Likelihood testing scenario from https://arxiv.org/pdf/2112.03570.pdf."""
+"""Likelihood testing scenario from https://arxiv.org/pdf/2112.03570.pdf.
+
+See p.6 (top of second column) for details.
+
+With mode "offline", we measure the probability of observing a
+confidence as high as the target model's under the null-hypothesis that
+the target point is a non-member. That is we, use the norm CDF.
+
+With mode "offline-carlini", we measure the probability that a target point
+did not come from the non-member distribution. That is, we use Carlini's
+implementation with a single norm (log) PDF.
+
+With mode "online-carlini", we use Carlini's implementation of the standard
+likelihood ratio test, measuring the ratio of probabilities the sample came
+from the two distributions. That is, the (log) PDF of pr_in minus pr_out.
+"""
 
 from __future__ import annotations
 
@@ -150,25 +165,10 @@ class LIRAAttack(Attack):
     ) -> None:
         """Run the likelihood test.
 
-        See p.6 (top of second column) for details.
-
-        With mode "offline", we measure the probability of observing a
-        confidence as high as the target model's under the null-hypothesis that
-        the target point is a non-member. That is we, use the norm CDF.
-
-        With mode "offline-carlini", we measure the probability that a target point
-        did not come from the non-member distribution. That is, we use Carlini's
-        implementation with a single norm (log) PDF.
-
-        With mode "online-carlini", we use Carlini's implementation of the standard
-        likelihood ratio test, measuring the ratio of probabilities the sample came
-        from the two distributions. That is, the (log) PDF of pr_in minus pr_out.
-
         Parameters
         ----------
         shadow_clf : Model
             A classifier that will be trained to form the shadow models.
-            All hyperparameters should have been set.
         X_train : np.ndarray
             Data that was used to train the target model.
         y_train : np.ndarray

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -582,7 +582,6 @@ def _logit(p: float) -> float:
     instabilities. This code thresholds `p` at `EPS` and `1 - EPS` where `EPS`
     defaults at 1e-16.
     """
-    if p > 1 - EPS:
-        p = 1 - EPS
+    p = min(p, 1 - EPS)
     p = max(p, EPS)
     return np.log(p / (1 - p))

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -18,7 +18,6 @@ from the two distributions. That is, the (log) PDF of pr_in minus pr_out.
 from __future__ import annotations
 
 import logging
-import os
 
 import numpy as np
 from fpdf import FPDF
@@ -89,10 +88,6 @@ class LIRAAttack(Attack):
                 self.result["in_prob"] = []
                 self.result["in_mean"] = []
                 self.result["in_std"] = []
-
-        # Create folder for saving trained shadow models
-        shadow_path: str = os.path.normpath(f"{self.output_dir}/shadow_models")
-        os.makedirs(shadow_path, exist_ok=True)
 
     def __str__(self):
         """Return the name of the attack."""
@@ -198,7 +193,7 @@ class LIRAAttack(Attack):
             combined_y_train=combined_data["labels"],
             n_train_rows=n_train_rows,
             n_shadow_models=self.n_shadow_models,
-            output_dir=self.output_dir,
+            shadow_path=self.shadow_path,
         )
 
         out_conf, in_conf = self._get_shadow_signals(
@@ -233,7 +228,7 @@ class LIRAAttack(Attack):
             Dictionary of confidences when not in the training set.
             Dictionary of confidences when in the training set.
         """
-        n_shadow_models: int = utils.get_n_shadow_models(self.output_dir)
+        n_shadow_models: int = utils.get_n_shadow_models(self.shadow_path)
         n_combined: int = combined_x_train.shape[0]
         out_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
         in_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
@@ -243,7 +238,7 @@ class LIRAAttack(Attack):
         for model_idx in range(n_shadow_models):
             # load shadow model
             shadow_clf, indices_train, _ = utils.get_shadow_model(
-                self.output_dir, model_idx
+                self.shadow_path, model_idx
             )
             # map a class to a column
             class_map = {c: i for i, c in enumerate(shadow_clf.get_classes())}

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -225,7 +225,7 @@ class LIRAAttack(Attack):
         n_train_rows = X_train.shape[0]
         n_shadow_rows = X_test.shape[0]
 
-        combined_data = self._combine_data(
+        combined_data = _combine_data(
             X_train, y_train, proba_train, X_test, y_test, proba_test
         )
 
@@ -247,29 +247,6 @@ class LIRAAttack(Attack):
 
         self._save_attack_metrics(mia_scores, n_train_rows, n_shadow_rows, n_normal)
         logger.info("Finished scenario")
-
-    def _combine_data(
-        self,
-        X_train: np.ndarray,
-        y_train: np.ndarray,
-        proba_train: np.ndarray,
-        X_test: np.ndarray,
-        y_test: np.ndarray,
-        proba_test: np.ndarray,
-    ) -> dict[str, np.ndarray]:
-        """Combine training and test data.
-
-        Assumes label encoding.
-        """
-        combined_features = np.vstack((X_train, X_test))
-        combined_labels = np.hstack((y_train, y_test))
-        combined_predictions = np.vstack((proba_train, proba_test))
-
-        return {
-            "features": combined_features,
-            "labels": combined_labels,
-            "predictions": combined_predictions,
-        }
 
     def _train_shadow_models(
         self,
@@ -561,6 +538,26 @@ class LIRAAttack(Attack):
         def predict_proba(self, X_test):
             """Simply return the X_test."""
             return X_test
+
+
+def _combine_data(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    proba_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    proba_test: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Return a dictionary combining training and test data."""
+    combined_features = np.vstack((X_train, X_test))
+    combined_labels = np.hstack((y_train, y_test))
+    combined_predictions = np.vstack((proba_train, proba_test))
+
+    return {
+        "features": combined_features,
+        "labels": combined_labels,
+        "predictions": combined_predictions,
+    }
 
 
 def _logit(p: float) -> float:

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -280,7 +280,7 @@ class LIRAAttack(Attack):
         global_out_std: float = self._get_global_std(out_conf)
 
         for i, label in enumerate(combined_y_train):
-            logit = utils.logit(combined_target_preds[i, label])
+            logit: float = utils.logit(combined_target_preds[i, label])
 
             out_mean, out_std = self._get_mean_std(out_conf[i], global_out_std)
             in_mean, in_std = self._get_mean_std(in_conf[i], global_in_std)

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -293,17 +293,17 @@ class LIRAAttack(Attack):
                 n_normal += 1
 
             if self.report_individual:
-                self._save_individual_result(
-                    label,
-                    logit,
-                    out_conf[i],
-                    pr_out,
-                    out_mean,
-                    out_std,
-                    pr_in,
-                    in_mean,
-                    in_std,
-                )
+                out_p_norm: float = utils.get_p_normal(np.array(out_conf[i]))
+                self.result["label"].append(label)
+                self.result["target_logit"].append(logit)
+                self.result["out_p_norm"].append(out_p_norm)
+                self.result["out_prob"].append(pr_out)
+                self.result["out_mean"].append(out_mean)
+                self.result["out_std"].append(out_std + EPS)
+                if self.mode == "online-carlini":
+                    self.result["in_prob"].append(pr_in)
+                    self.result["in_mean"].append(in_mean)
+                    self.result["in_std"].append(in_std + EPS)
 
         return mia_scores, n_normal
 
@@ -353,33 +353,6 @@ class LIRAAttack(Attack):
             self.result["score"] = [score[1] for score in mia_scores]
             self.result["member"] = mia_labels
             self.attack_metrics[-1]["individual"] = self.result
-
-    def _save_individual_result(
-        self,
-        label: int,
-        target_logit: float,
-        out_conf_sample: list[float],
-        pr_out: float,
-        out_mean: float,
-        out_std: float,
-        pr_in: float,
-        in_mean: float,
-        in_std: float,
-    ) -> None:
-        """Save individual record result."""
-        out_p_norm = utils.get_p_normal(np.array(out_conf_sample))
-
-        self.result["label"].append(label)
-        self.result["target_logit"].append(target_logit)
-        self.result["out_p_norm"].append(out_p_norm)
-        self.result["out_prob"].append(pr_out)
-        self.result["out_mean"].append(out_mean)
-        self.result["out_std"].append(out_std + EPS)
-
-        if self.mode == "online-carlini":
-            self.result["in_prob"].append(pr_in)
-            self.result["in_mean"].append(in_mean)
-            self.result["in_std"].append(in_std + EPS)
 
     def _get_mean_std(
         self, confidences: list[float], global_std: float

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -228,14 +228,13 @@ class LIRAAttack(Attack):
             Dictionary of confidences when not in the training set.
             Dictionary of confidences when in the training set.
         """
-        n_shadow_models: int = utils.get_n_shadow_models(self.shadow_path)
         n_combined: int = combined_x_train.shape[0]
         out_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
         in_conf: dict[int, list[float]] = {i: [] for i in range(n_combined)}
 
-        logger.info("Getting signals from %d shadow models", n_shadow_models)
+        logger.info("Getting signals from %d shadow models", self.n_shadow_models)
 
-        for model_idx in range(n_shadow_models):
+        for model_idx in range(self.n_shadow_models):
             # load shadow model
             shadow_clf, indices_train, _ = utils.get_shadow_model(
                 self.shadow_path, model_idx

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -225,7 +225,7 @@ class LIRAAttack(Attack):
         n_train_rows = X_train.shape[0]
         n_shadow_rows = X_test.shape[0]
 
-        combined_data = self._combine_training_data(
+        combined_data = self._combine_data(
             X_train, y_train, proba_train, X_test, y_test, proba_test
         )
 
@@ -248,7 +248,7 @@ class LIRAAttack(Attack):
         self._save_attack_metrics(mia_scores, n_train_rows, n_shadow_rows, n_normal)
         logger.info("Finished scenario")
 
-    def _combine_training_data(
+    def _combine_data(
         self,
         X_train: np.ndarray,
         y_train: np.ndarray,

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -255,7 +255,7 @@ class LIRAAttack(Attack):
                 # Occasionally, the random data split will result in classes being
                 # absent from the training set. In these cases label will be -1 and
                 # we include logit(0) instead of discarding
-                logit = _logit(0) if label < 0 else _logit(conf[label])
+                logit = utils.logit(0) if label < 0 else utils.logit(conf[label])
                 if i not in indices_train:
                     out_conf[i].append(logit)
                 else:
@@ -278,7 +278,7 @@ class LIRAAttack(Attack):
         global_out_std: float = self._get_global_std(out_conf)
 
         for i, label in enumerate(combined_y_train):
-            logit = _logit(combined_target_preds[i, label])
+            logit = utils.logit(combined_target_preds[i, label])
 
             out_mean, out_std = self._get_mean_std(out_conf[i], global_out_std)
             in_mean, in_std = self._get_mean_std(in_conf[i], global_in_std)
@@ -480,27 +480,3 @@ def _combine_data(
         "labels": combined_labels,
         "predictions": combined_predictions,
     }
-
-
-def _logit(p: float) -> float:
-    """Return standard logit.
-
-    Parameters
-    ----------
-    p : float
-        value to evaluate logit at.
-
-    Returns
-    -------
-    float
-        logit(p)
-
-    Notes
-    -----
-    If `p` is close to 0 or 1, evaluating the log will result in numerical
-    instabilities. This code thresholds `p` at `EPS` and `1 - EPS` where `EPS`
-    defaults at 1e-16.
-    """
-    p = min(p, 1 - EPS)
-    p = max(p, EPS)
-    return np.log(p / (1 - p))

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -336,7 +336,7 @@ class LIRAAttack(Attack):
             pr_out = -norm.logpdf(logit, out_mean, out_std + EPS)
             pr_in = -pr_out
         else:
-            raise ValueError(f"Unsupported LiRA mode: {self.mode}")
+            raise ValueError(f"Unsupported LiRA mode: {mode}")
 
         return float(pr_in), float(pr_out)
 

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -184,12 +184,14 @@ class LIRAAttack(Attack):
         """
         logger.info("Running %s LiRA, fix_variance=%s", self.mode, self.fix_variance)
 
-        n_train_rows = X_train.shape[0]
-        n_shadow_rows = X_test.shape[0]
+        n_train_rows: int = X_train.shape[0]
+        n_shadow_rows: int = X_test.shape[0]
 
-        combined_data = _combine_data(
-            X_train, y_train, proba_train, X_test, y_test, proba_test
-        )
+        combined_data: dict[str, np.ndarray] = {
+            "features": np.vstack((X_train, X_test)),
+            "labels": np.hstack((y_train, y_test)),
+            "predictions": np.vstack((proba_train, proba_test)),
+        }
 
         utils.train_shadow_models(
             shadow_clf=shadow_clf,
@@ -460,23 +462,3 @@ class LIRAAttack(Attack):
         def predict_proba(self, X_test):
             """Simply return the X_test."""
             return X_test
-
-
-def _combine_data(
-    X_train: np.ndarray,
-    y_train: np.ndarray,
-    proba_train: np.ndarray,
-    X_test: np.ndarray,
-    y_test: np.ndarray,
-    proba_test: np.ndarray,
-) -> dict[str, np.ndarray]:
-    """Return a dictionary combining training and test data."""
-    combined_features = np.vstack((X_train, X_test))
-    combined_labels = np.hstack((y_train, y_test))
-    combined_predictions = np.vstack((proba_train, proba_test))
-
-    return {
-        "features": combined_features,
-        "labels": combined_labels,
-        "predictions": combined_predictions,
-    }

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -93,7 +93,7 @@ def train_shadow_models(
     logger.info("Training shadow models")
 
     n_models_trained: int = get_n_shadow_models(output_dir)
-    if n_models_trained > 0:
+    if n_models_trained > 0:  # pragma: no cover
         logger.info("Reusing %d models previously trained", n_models_trained)
 
     n_combined: int = combined_x_train.shape[0]

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -73,6 +73,8 @@ def train_shadow_models(
 ) -> None:
     """Train and save shadow models.
 
+    Reuses any saved models that are available.
+
     Parameters
     ----------
     shadow_clf : Model
@@ -90,10 +92,14 @@ def train_shadow_models(
     """
     logger.info("Training shadow models")
 
+    n_models_trained: int = get_n_shadow_models(output_dir)
+    if n_models_trained > 0:
+        logger.info("Reusing %d models previously trained", n_models_trained)
+
     n_combined: int = combined_x_train.shape[0]
     indices: np.ndarray = np.arange(0, n_combined, 1)
 
-    for idx in range(n_shadow_models):
+    for idx in range(n_models_trained, n_shadow_models):
         if idx % 10 == 0:
             logger.info("Trained %d models", idx)
 

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -152,7 +152,7 @@ def get_shadow_model(shadow_path: str, idx: int) -> tuple[Any, np.ndarray, np.nd
 def get_n_shadow_models(shadow_path: str) -> int:
     """Return the number shadow models saved."""
     count: int = 0
-    for item in os.listdir(shadow_path):
+    for item in os.listdir(shadow_path):  # pragma: no cover
         item_path = os.path.join(shadow_path, item)
         if os.path.isdir(item_path):
             count += 1

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -1,11 +1,112 @@
 """Utility functions for attacks."""
 
 import contextlib
+import importlib
+import logging
+import os
+import pickle
+from typing import Any
 
 import numpy as np
 from scipy.stats import shapiro
 
+from sacroml.attacks.model import Model
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 EPS: float = 1e-16  # Used to avoid numerical issues
+
+
+def train_shadow_models(
+    shadow_clf: Model,
+    combined_x_train: np.ndarray,
+    combined_y_train: np.ndarray,
+    n_train_rows: int,
+    n_shadow_models: int,
+    output_dir: str,
+) -> None:
+    """Train and save shadow models.
+
+    Parameters
+    ----------
+    shadow_clf : Model
+        A classifier that will be trained to form the shadow models.
+    combined_x_train : np.ndarray
+        Array of combined train and test features.
+    combined_y_train : np.ndarray
+        Array of combined train and test labels.
+    n_train_rows : int
+        Number of samples in the training set.
+    n_shadow_models : int
+        Number of shadow models to train.
+    output_dir : str
+        Location to save shadow models.
+    """
+    logger.info("Training shadow models")
+
+    n_combined: int = combined_x_train.shape[0]
+    indices: np.ndarray = np.arange(0, n_combined, 1)
+
+    for idx in range(n_shadow_models):
+        if idx % 10 == 0:
+            logger.info("Trained %d models", idx)
+
+        # Pick the indices to use for training this shadow model
+        np.random.seed(idx)
+        indices_train = np.random.choice(indices, n_train_rows, replace=False)
+        indices_test = np.setdiff1d(indices, indices_train)
+
+        # Fit the shadow model
+        shadow_clf.set_params(random_state=idx)
+        shadow_clf.fit(
+            combined_x_train[indices_train, :],
+            combined_y_train[indices_train],
+        )
+
+        # Save model and indices
+        save_shadow_model(output_dir, idx, shadow_clf, indices_train, indices_test)
+
+
+def save_shadow_model(
+    output_dir: str,
+    idx: int,
+    model: Any,
+    indices_train: np.ndarray,
+    indices_test: np.ndarray,
+) -> None:
+    """Save a trained shadow model."""
+    path: str = os.path.normpath(f"{output_dir}/shadow_models/{idx}")
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "model.pkl"), "wb") as f:
+        pickle.dump(model, f)
+    with open(os.path.join(path, "indices_train.pkl"), "wb") as f:
+        pickle.dump(indices_train, f)
+    with open(os.path.join(path, "indices_test.pkl"), "wb") as f:
+        pickle.dump(indices_test, f)
+
+
+def get_shadow_model(output_dir: str, idx: int) -> tuple[Any, np.ndarray, np.ndarray]:
+    """Return a shadow model and indices previously saved."""
+    path: str = os.path.normpath(f"{output_dir}/shadow_models/{idx}")
+    with open(os.path.join(path, "model.pkl"), "rb") as f:
+        model = pickle.load(f)
+    with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
+        indices_train = pickle.load(f)
+    with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
+        indices_test = pickle.load(f)
+    return model, indices_train, indices_test
+
+
+def get_n_shadow_models(output_dir: str) -> int:
+    """Return the number shadow models saved."""
+    path: str = os.path.normpath(f"{output_dir}/shadow_models")
+    count: int = 0
+    for item in os.listdir(path):
+        item_path = os.path.join(path, item)
+        if os.path.isdir(item_path):
+            count += 1
+    return count
 
 
 def get_p_normal(samples: np.ndarray) -> float:
@@ -15,3 +116,10 @@ def get_p_normal(samples: np.ndarray) -> float:
         with contextlib.suppress(ValueError):
             _, p_normal = shapiro(samples)
     return p_normal
+
+
+def get_class_by_name(class_path: str):
+    """Return a class given its name."""
+    module_path, class_name = class_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -1,0 +1,17 @@
+"""Utility functions for attacks."""
+
+import contextlib
+
+import numpy as np
+from scipy.stats import shapiro
+
+EPS: float = 1e-16  # Used to avoid numerical issues
+
+
+def get_p_normal(samples: np.ndarray) -> float:
+    """Test whether a set of samples is normally distributed."""
+    p_normal: float = np.nan
+    if np.nanvar(samples) > EPS:
+        with contextlib.suppress(ValueError):
+            _, p_normal = shapiro(samples)
+    return p_normal

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -69,7 +69,7 @@ def train_shadow_models(
     combined_y_train: np.ndarray,
     n_train_rows: int,
     n_shadow_models: int,
-    output_dir: str,
+    shadow_path: str,
 ) -> None:
     """Train and save shadow models.
 
@@ -87,12 +87,12 @@ def train_shadow_models(
         Number of samples in the training set.
     n_shadow_models : int
         Number of shadow models to train.
-    output_dir : str
+    shadow_path : str
         Location to save shadow models.
     """
     logger.info("Training shadow models")
 
-    n_models_trained: int = get_n_shadow_models(output_dir)
+    n_models_trained: int = get_n_shadow_models(shadow_path)
     if n_models_trained > 0:  # pragma: no cover
         logger.info("Reusing %d models previously trained", n_models_trained)
 
@@ -116,18 +116,18 @@ def train_shadow_models(
         )
 
         # Save model and indices
-        save_shadow_model(output_dir, idx, shadow_clf, indices_train, indices_test)
+        save_shadow_model(shadow_path, idx, shadow_clf, indices_train, indices_test)
 
 
 def save_shadow_model(
-    output_dir: str,
+    shadow_path: str,
     idx: int,
     model: Any,
     indices_train: np.ndarray,
     indices_test: np.ndarray,
 ) -> None:
     """Save a trained shadow model."""
-    path: str = os.path.normpath(f"{output_dir}/shadow_models/{idx}")
+    path: str = os.path.normpath(f"{shadow_path}/{idx}")
     os.makedirs(path, exist_ok=True)
     with open(os.path.join(path, "model.pkl"), "wb") as f:
         pickle.dump(model, f)
@@ -137,9 +137,9 @@ def save_shadow_model(
         pickle.dump(indices_test, f)
 
 
-def get_shadow_model(output_dir: str, idx: int) -> tuple[Any, np.ndarray, np.ndarray]:
+def get_shadow_model(shadow_path: str, idx: int) -> tuple[Any, np.ndarray, np.ndarray]:
     """Return a shadow model and indices previously saved."""
-    path: str = os.path.normpath(f"{output_dir}/shadow_models/{idx}")
+    path: str = os.path.normpath(f"{shadow_path}/{idx}")
     with open(os.path.join(path, "model.pkl"), "rb") as f:
         model = pickle.load(f)
     with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
@@ -149,12 +149,11 @@ def get_shadow_model(output_dir: str, idx: int) -> tuple[Any, np.ndarray, np.nda
     return model, indices_train, indices_test
 
 
-def get_n_shadow_models(output_dir: str) -> int:
+def get_n_shadow_models(shadow_path: str) -> int:
     """Return the number shadow models saved."""
-    path: str = os.path.normpath(f"{output_dir}/shadow_models")
     count: int = 0
-    for item in os.listdir(path):
-        item_path = os.path.join(path, item)
+    for item in os.listdir(shadow_path):
+        item_path = os.path.join(shadow_path, item)
         if os.path.isdir(item_path):
             count += 1
     return count

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -94,7 +94,7 @@ def train_shadow_models(
 
     n_models_trained: int = get_n_shadow_models(shadow_path)
     if n_models_trained > 0:  # pragma: no cover
-        logger.info("Reusing %d models previously trained", n_models_trained)
+        logger.info("Found %d models previously trained", n_models_trained)
 
     n_combined: int = combined_x_train.shape[0]
     indices: np.ndarray = np.arange(0, n_combined, 1)

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -163,6 +163,30 @@ def get_p_normal(samples: np.ndarray) -> float:
     return p_normal
 
 
+def logit(p: float) -> float:
+    """Return standard logit.
+
+    Parameters
+    ----------
+    p : float
+        value to evaluate logit at.
+
+    Returns
+    -------
+    float
+        logit(p)
+
+    Notes
+    -----
+    If `p` is close to 0 or 1, evaluating the log will result in numerical
+    instabilities. This code thresholds `p` at `EPS` and `1 - EPS` where `EPS`
+    defaults at 1e-16.
+    """
+    p = min(p, 1 - EPS)
+    p = max(p, EPS)
+    return np.log(p / (1 - p))
+
+
 def get_class_by_name(class_path: str):
     """Return a class given its name."""
     module_path, class_name = class_path.rsplit(".", 1)

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -12,8 +12,9 @@ from sklearn.model_selection import train_test_split
 
 from sacroml import metrics
 from sacroml.attacks import report
-from sacroml.attacks.attack import Attack, get_class_by_name
+from sacroml.attacks.attack import Attack
 from sacroml.attacks.target import Target
+from sacroml.attacks.utils import get_class_by_name
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Resolves #347 and resolves #351 

* Move shadow model training to `sacroml/attacks/utils.py` and save trained models and indices to subfolders;
* Reuse any previously trained models;
   - This means that if different LiRA modes need to be computed (e.g., offline and online) a new attack object can simply be created with a different mode and it will quickly run the attack using previously trained models and save the output to the report JSON and PDF.
    - Any other future attacks that may use shadow models can reuse these trained models;
    - A small number of shadow models (e.g., 10) can be initially be used to compute scores and then if needed a subsequent attack object with a larger number (e.g., 20) can be run and it will only need to train the additional models;