### PR TITLE
chore: prepare v1.4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## Version 1.4.1 (Oct 27, 2025)
+
 Changes:
 *   Add example running attacks with only csv probabilities supplied ([#353](https://github.com/AI-SDC/SACRO-ML/pull/353))
-*   Add PDF report generation for structural attacks ([#355](https://github.com/AI-SDC/SACRO-ML/pull/355))
 *   Save and reuse trained shadow models ([#357](https://github.com/AI-SDC/SACRO-ML/pull/357))
+*   Refactor `StructualAttack`, add PDF report generation, record level reporting, and PyTorch support ([#355](https://github.com/AI-SDC/SACRO-ML/pull/355), [#362](https://github.com/AI-SDC/SACRO-ML/pull/362), [#367](https://github.com/AI-SDC/SACRO-ML/pull/367))
+*   Add more documentation ([#374](https://github.com/AI-SDC/SACRO-ML/pull/374), [#375](https://github.com/AI-SDC/SACRO-ML/pull/375))
 
 ## Version 1.4.0 (Jul 4, 2025)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 title: SACRO-ML
-version: 1.4.0
-doi: 10.5281/zenodo.15806814
-date-released: 2025-07-04
+version: 1.4.1
+doi:
+date-released: 2025-10-27
 license: MIT
 repository-code: https://github.com/AI-SDC/SACRO-ML
 languages:
@@ -53,6 +53,9 @@ authors:
     given-names: Jost
     affiliation: King's College London
     orcid: https://orcid.org/0000-0002-5350-8049
+  - family-names: Atefi
+    given-names: Kay
+    affiliation: University of the West of England
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7080279

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sacroml"
 dynamic = ["version"]
 description = "Tools for the statistical disclosure control of machine learning models"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 maintainers = [
     {name = "Jim Smith", email = "james.smith@uwe.ac.uk"}
@@ -26,11 +26,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -87,7 +87,7 @@ packages = {find = {exclude = ["docs*", "examples*", "tests*", "user_stories*"]}
 [tool.ruff]
 indent-width = 4
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 extend-include = ["*.ipynb"]
 
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -161,7 +161,7 @@ def _unique_max(confidences: list[float], threshold: float) -> bool:
         if max_conf < threshold:
             return False
         unique, count = np.unique(confidences, return_counts=True)
-        for u, c in zip(unique, count):
+        for u, c in zip(unique, count, strict=False):
             if c == 1 and u == max_conf:
                 return True
     return False

--- a/sacroml/version.py
+++ b/sacroml/version.py
@@ -1,3 +1,3 @@
 """SACRO-ML version number."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
Prepare for v1.4.1

Increments the version number and updates minimum Python version to 3.10.

Note: SACRO-ML cannot yet support Python 3.14 due to [ACRO dependencies](https://github.com/AI-SDC/ACRO/issues/276).