### PR TITLE
chore: bump acro==0.4.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,11 @@
 ---
-name: Tests Manually Run
+name: Tests
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -21,6 +25,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
 
       # xgboost requires libomp on macOS
       - name: Install dependencies on macOS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,7 @@
 ---
-name: Tests
+name: Tests Manually Run
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 
 jobs:
   build:
@@ -25,7 +21,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
 
       # xgboost requires libomp on macOS
       - name: Install dependencies on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,14 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "acro==0.4.9",
+    "acro==0.4.11",
     "fpdf",
     "pypdf",
     "multiprocess",


### PR DESCRIPTION
Updates acro dependency to v0.4.11 to enable Python 3.14 support.