### PR TITLE
fix: read indices_test.pkl in get_shadow_model

### DIFF
--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -145,7 +145,7 @@ def get_shadow_model(shadow_path: str, idx: int) -> tuple[Any, np.ndarray, np.nd
         model = pickle.load(f)
     with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
         indices_train = pickle.load(f)
-    with open(os.path.join(path, "indices_train.pkl"), "rb") as f:
+    with open(os.path.join(path, "indices_test.pkl"), "rb") as f:
         indices_test = pickle.load(f)
     return model, indices_train, indices_test
 


### PR DESCRIPTION
Fixes #442

`get_shadow_model` in `sacroml/attacks/utils.py` was opening `indices_train.pkl` twice, so the returned `indices_test` actually contained the train indices.
- `save_shadow_model` has always written both files correctly (since #357)