### PR TITLE
feat: sklearn-compatible scorers for mia metrics (groundwork for #350)

### DIFF
--- a/sacroml/attacks/_scorers.py
+++ b/sacroml/attacks/_scorers.py
@@ -1,0 +1,132 @@
+"""Sklearn-compatible scorers for MIA metrics from :func:`sacroml.metrics.get_metrics`.
+
+These scorers conform to the standard sklearn scorer call protocol
+``(estimator, X, y)`` and can be passed directly to ``GridSearchCV`` /
+``RandomizedSearchCV`` via the ``scoring`` argument.
+
+The metrics produced by :func:`sacroml.metrics.get_metrics` are richer than
+what :func:`sklearn.metrics.make_scorer` can address through its standard
+``score_func(y_true, y_pred)`` signature, so each scorer is implemented as a
+``functools.partial`` over a single private function that runs
+``predict_proba`` and pulls the requested key out of the metrics dict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+
+import numpy as np
+from sklearn.base import BaseEstimator
+from sklearn.metrics import get_scorer_names
+
+from sacroml import metrics
+
+Scorer = Callable[[BaseEstimator, np.ndarray, np.ndarray], float]
+
+_SCORER_KEYS: tuple[str, ...] = (
+    "AUC",
+    "TPR@0.1",
+    "TPR@0.001",
+    "FDIF01",
+    "FDIF02",
+    "Advantage",
+    "PDIF01",
+)
+
+
+def _score_from_metrics(
+    estimator: BaseEstimator,
+    X: np.ndarray,
+    y_true: np.ndarray,
+    *,
+    key: str,
+) -> float:
+    """Compute a single MIA metric via :func:`sacroml.metrics.get_metrics`.
+
+    Conforms to the sklearn scorer call protocol ``(estimator, X, y)`` so it
+    can be used directly (or via :func:`functools.partial`) as the ``scoring``
+    argument of any sklearn search/CV object.
+
+    Parameters
+    ----------
+    estimator : sklearn.base.BaseEstimator
+        A fitted estimator exposing ``predict_proba``.
+    X : np.ndarray
+        Feature matrix passed to ``estimator.predict_proba``.
+    y_true : np.ndarray
+        True labels (binary; the shape required by
+        :func:`sacroml.metrics.get_metrics`).
+    key : str
+        Name of the metric to extract from the dict returned by
+        :func:`sacroml.metrics.get_metrics`.
+
+    Returns
+    -------
+    float
+        The value at ``key`` cast to ``float``.
+
+    Raises
+    ------
+    KeyError
+        If ``key`` is not present in the metrics dict. The error message
+        lists the keys that are available.
+    """
+    y_pred_proba = estimator.predict_proba(X)
+    out = metrics.get_metrics(y_pred_proba, y_true)
+    if key not in out:
+        available = sorted(out.keys())
+        msg = (
+            f"Metric key {key!r} not found in get_metrics output. "
+            f"Available keys: {available}."
+        )
+        raise KeyError(msg)
+    return float(out[key])
+
+
+SCORERS: dict[str, Scorer] = {
+    name: partial(_score_from_metrics, key=name) for name in _SCORER_KEYS
+}
+
+
+def resolve_scorer(name: str | Scorer) -> str | Scorer:
+    """Resolve a scorer specifier into a value usable as sklearn ``scoring``.
+
+    Parameters
+    ----------
+    name : str or Callable
+        - A callable is returned unchanged (assumed to be a user-supplied
+          scorer following the ``(estimator, X, y)`` protocol).
+        - A string in :data:`SCORERS` returns the corresponding partial.
+        - A string accepted by sklearn (e.g. ``"roc_auc"``) is returned
+          unchanged so sklearn resolves it at fit time.
+
+    Returns
+    -------
+    str or Callable
+        Either the original callable, the matching :data:`SCORERS` entry, or
+        the input string passed through to sklearn.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is neither a callable, a known MIA scorer name, nor a
+        recognised sklearn scoring string.
+    """
+    if callable(name):
+        return name
+    if not isinstance(name, str):
+        msg = f"Scorer must be a callable or a string; got {type(name).__name__}."
+        raise ValueError(msg)
+    if name in SCORERS:
+        return SCORERS[name]
+    if name in get_scorer_names():
+        return name
+    available_mia = sorted(SCORERS.keys())
+    msg = (
+        f"Unknown scorer {name!r}. "
+        f"Known MIA scorers: {available_mia}. "
+        "Any sklearn scoring string (see sklearn.metrics.get_scorer_names()) "
+        "is also valid."
+    )
+    raise ValueError(msg)

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -144,7 +144,11 @@ class WorstCaseAttack(Attack):
             attack_model_param_grid
         )
         self.search_type: str = search_type
+        if not isinstance(search_n_iter, int) or search_n_iter < 1:
+            msg = f"search_n_iter must be a positive integer; got {search_n_iter!r}."
+            raise ValueError(msg)
         self.search_n_iter: int = search_n_iter
+        resolve_scorer(tuning_metric)
         self.tuning_metric: str | Callable = tuning_metric
         self.dummy_attack_metrics: list = []
         self._tuned_params: dict | None = None
@@ -313,6 +317,19 @@ class WorstCaseAttack(Attack):
         # instantiate attack model
         return model(**params) if params is not None else model()
 
+    def _make_rep_splitter(self, random_state: int) -> StratifiedShuffleSplit:
+        """Splitter used by both the tuning search and the rep loop.
+
+        Both call sites must produce byte-identical folds for the
+        "tuning counts toward n_reps" property to hold; centralising
+        construction here prevents the two from drifting.
+        """
+        return StratifiedShuffleSplit(
+            n_splits=self.n_reps,
+            test_size=self.test_prop,
+            random_state=random_state,
+        )
+
     def _resolve_param_grid(self) -> dict | list[dict] | None:
         """Return the parameter grid, or ``None`` if tuning is disabled."""
         grid = self.attack_model_param_grid
@@ -355,11 +372,7 @@ class WorstCaseAttack(Attack):
                 f"at least 2 folds; got n_reps={self.n_reps}."
             )
             raise ValueError(msg)
-        splitter = StratifiedShuffleSplit(
-            n_splits=self.n_reps,
-            test_size=self.test_prop,
-            random_state=random_state,
-        )
+        splitter = self._make_rep_splitter(random_state)
         scorer = resolve_scorer(self.tuning_metric)
         base_estimator = self._get_attack_model()
         if self.search_type == "grid":
@@ -407,9 +420,15 @@ class WorstCaseAttack(Attack):
                 strict=True,
             )
         ]
+        best_idx = int(np.flatnonzero(cv_results["rank_test_score"] == 1)[0])
+        best_candidate_per_fold_scores = [
+            float(cv_results[f"split{i}_test_score"][best_idx])
+            for i in range(self.n_reps)
+        ]
         self._tuning_info = {
             "best_params": dict(search.best_params_),
             "best_score": float(search.best_score_),
+            "best_candidate_per_fold_scores": best_candidate_per_fold_scores,
             "tuning_metric": (
                 self.tuning_metric
                 if isinstance(self.tuning_metric, str)
@@ -485,11 +504,7 @@ class WorstCaseAttack(Attack):
         if self._tuned_params is not None:
             # Use the same CV splits the search ran over so the "reps" and
             # the "tuning CV folds" coincide (the tuning counts toward n_reps).
-            splitter = StratifiedShuffleSplit(
-                n_splits=self.n_reps,
-                test_size=self.test_prop,
-                random_state=split[0],
-            )
+            splitter = self._make_rep_splitter(split[0])
             fold_splits = list(splitter.split(mi_x, mi_y))
         else:
             # Legacy path: variable random states per rep (one resample each).

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import numpy as np
 from fpdf import FPDF
 from sklearn.base import BaseEstimator
 from sklearn.metrics import confusion_matrix
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import (
+    GridSearchCV,
+    RandomizedSearchCV,
+    StratifiedShuffleSplit,
+    train_test_split,
+)
 
 from sacroml import metrics
 from sacroml.attacks import report
+from sacroml.attacks._scorers import resolve_scorer
 from sacroml.attacks.attack import Attack
 from sacroml.attacks.target import Target
 from sacroml.attacks.utils import get_class_by_name
@@ -22,6 +28,21 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 P_THRESH = 0.05
+
+_DEFAULT_PARAM_GRIDS: dict[str, dict[str, list]] = {
+    "sklearn.ensemble.RandomForestClassifier": {
+        "min_samples_split": [2, 10, 20],
+        "min_samples_leaf": [1, 5, 10],
+        "max_depth": [None, 5, 10],
+    },
+    "sklearn.neural_network.MLPClassifier": {
+        "hidden_layer_sizes": [(50,), (100,), (50, 50)],
+        "alpha": [1e-4, 1e-3, 1e-2],
+    },
+    "sklearn.linear_model.LogisticRegression": {
+        "C": [0.01, 0.1, 1.0, 10.0],
+    },
+}
 
 
 class WorstCaseAttack(Attack):
@@ -42,6 +63,10 @@ class WorstCaseAttack(Attack):
         sort_probs: bool = True,
         attack_model: str = "sklearn.ensemble.RandomForestClassifier",
         attack_model_params: dict[str, object] | None = None,
+        attack_model_param_grid: dict | list[dict] | str | None = None,
+        search_type: str = "grid",
+        search_n_iter: int = 10,
+        tuning_metric: str | Callable = "AUC",
     ) -> None:
         """Construct an object to execute a worst case attack.
 
@@ -82,6 +107,26 @@ class WorstCaseAttack(Attack):
         attack_model_params : dict or None
             Dictionary of hyperparameters for the `attack_model`
             such as `min_sample_split`, `min_samples_leaf`, etc.
+        attack_model_param_grid : dict, list[dict], "default", or None
+            If ``None`` (default) no tuning is performed and behaviour
+            matches earlier versions. If ``"default"``, a built-in grid for
+            the configured ``attack_model`` is used (see
+            ``_DEFAULT_PARAM_GRIDS``). Otherwise pass a sklearn-style grid
+            (a dict or list of dicts).
+        search_type : str
+            ``"grid"`` (default) or ``"random"`` to select between
+            :class:`~sklearn.model_selection.GridSearchCV` and
+            :class:`~sklearn.model_selection.RandomizedSearchCV`. Ignored
+            when ``attack_model_param_grid`` is ``None``.
+        search_n_iter : int
+            Number of parameter settings sampled when
+            ``search_type='random'``. Ignored otherwise.
+        tuning_metric : str or callable
+            Scoring metric used by the search. Defaults to ``"AUC"``.
+            Accepts any key in
+            :data:`sacroml.attacks._scorers.SCORERS`, any sklearn scoring
+            string, or a custom callable following the sklearn
+            ``(estimator, X, y)`` protocol.
         """
         super().__init__(output_dir=output_dir, write_report=write_report)
         self.n_reps: int = n_reps
@@ -95,7 +140,15 @@ class WorstCaseAttack(Attack):
         self.sort_probs: bool = sort_probs
         self.attack_model: str = attack_model
         self.attack_model_params: dict[str, object] | None = attack_model_params
+        self.attack_model_param_grid: dict | list[dict] | str | None = (
+            attack_model_param_grid
+        )
+        self.search_type: str = search_type
+        self.search_n_iter: int = search_n_iter
+        self.tuning_metric: str | Callable = tuning_metric
         self.dummy_attack_metrics: list = []
+        self._tuned_params: dict | None = None
+        self._tuning_info: dict | None = None
 
     def __str__(self) -> str:
         """Return name of attack."""
@@ -239,9 +292,14 @@ class WorstCaseAttack(Attack):
         return (mi_x, mi_y)
 
     def _get_attack_model(self) -> BaseEstimator:
-        """Return an instantiated attack model."""
-        # load attack model module and get class
+        """Return an instantiated attack model.
+
+        After tuning has run, ``self._tuned_params`` is preferred over
+        the constructor-supplied ``attack_model_params``.
+        """
         model = get_class_by_name(self.attack_model)
+        if self._tuned_params is not None:
+            return model(**self._tuned_params)
         params: dict[str, object] | None = self.attack_model_params
         if (  # set custom default parameters for RF attack model
             self.attack_model == "sklearn.ensemble.RandomForestClassifier"
@@ -254,6 +312,119 @@ class WorstCaseAttack(Attack):
             }
         # instantiate attack model
         return model(**params) if params is not None else model()
+
+    def _resolve_param_grid(self) -> dict | list[dict] | None:
+        """Return the parameter grid, or ``None`` if tuning is disabled."""
+        grid = self.attack_model_param_grid
+        if grid is None:
+            return None
+        if isinstance(grid, str):
+            if grid == "default":
+                if self.attack_model not in _DEFAULT_PARAM_GRIDS:
+                    available = sorted(_DEFAULT_PARAM_GRIDS.keys())
+                    msg = (
+                        f"No default param grid for attack_model "
+                        f"{self.attack_model!r}; defaults are available for: "
+                        f"{available}. Pass an explicit grid instead."
+                    )
+                    raise ValueError(msg)
+                return _DEFAULT_PARAM_GRIDS[self.attack_model]
+            msg = (
+                "attack_model_param_grid must be a dict, list of dicts, "
+                f'"default", or None; got string {grid!r}.'
+            )
+            raise ValueError(msg)
+        return grid
+
+    def _tune_if_needed(
+        self, mi_x: np.ndarray, mi_y: np.ndarray, random_state: int
+    ) -> None:
+        """Run the tuning search if a grid is configured.
+
+        A no-op when tuning has already been performed on this instance,
+        so dummy-attack repetitions reuse the params found by the real run.
+        """
+        if self._tuned_params is not None:
+            return
+        grid = self._resolve_param_grid()
+        if grid is None:
+            return
+        if self.n_reps < 2:
+            msg = (
+                "Tuning requires n_reps >= 2 because cross-validation needs "
+                f"at least 2 folds; got n_reps={self.n_reps}."
+            )
+            raise ValueError(msg)
+        splitter = StratifiedShuffleSplit(
+            n_splits=self.n_reps,
+            test_size=self.test_prop,
+            random_state=random_state,
+        )
+        scorer = resolve_scorer(self.tuning_metric)
+        base_estimator = self._get_attack_model()
+        if self.search_type == "grid":
+            search = GridSearchCV(
+                base_estimator,
+                grid,
+                cv=splitter,
+                scoring=scorer,
+                refit=False,
+                n_jobs=1,
+            )
+        elif self.search_type == "random":
+            search = RandomizedSearchCV(
+                base_estimator,
+                grid,
+                n_iter=self.search_n_iter,
+                cv=splitter,
+                scoring=scorer,
+                refit=False,
+                random_state=random_state,
+                n_jobs=1,
+            )
+        else:
+            msg = (
+                f"Unknown search_type {self.search_type!r}; "
+                "expected 'grid' or 'random'."
+            )
+            raise ValueError(msg)
+        logger.info("Tuning attack model via %s search over %s", self.search_type, grid)
+        search.fit(mi_x, mi_y)
+        self._tuned_params = dict(search.best_params_)
+        cv_results = search.cv_results_
+        candidates: list[dict] = [
+            {
+                "params": dict(params),
+                "mean_test_score": float(mean),
+                "std_test_score": float(std),
+                "rank_test_score": int(rank),
+            }
+            for params, mean, std, rank in zip(
+                cv_results["params"],
+                cv_results["mean_test_score"],
+                cv_results["std_test_score"],
+                cv_results["rank_test_score"],
+                strict=True,
+            )
+        ]
+        self._tuning_info = {
+            "best_params": dict(search.best_params_),
+            "best_score": float(search.best_score_),
+            "tuning_metric": (
+                self.tuning_metric
+                if isinstance(self.tuning_metric, str)
+                else getattr(self.tuning_metric, "__name__", repr(self.tuning_metric))
+            ),
+            "search_type": self.search_type,
+            "param_grid": grid,
+            "n_candidates": len(candidates),
+            "cv_results": candidates,
+        }
+        logger.info(
+            "Tuning best_params=%s best_score=%.4f",
+            self._tuned_params,
+            search.best_score_,
+        )
 
     def _get_reproducible_split(self) -> list:
         """Return a list of splits."""
@@ -308,20 +479,37 @@ class WorstCaseAttack(Attack):
             proba_train, proba_test, train_correct, test_correct
         )
 
-        mia_metrics: list[dict] = []
         split = self._get_reproducible_split()
+        self._tune_if_needed(mi_x, mi_y, random_state=split[0])
 
-        for rep in range(self.n_reps):
-            logger.info("Rep %d of %d split %d", rep + 1, self.n_reps, split[rep])
-
-            mi_train_x, mi_test_x, mi_train_y, mi_test_y = train_test_split(
-                mi_x,
-                mi_y,
+        if self._tuned_params is not None:
+            # Use the same CV splits the search ran over so the "reps" and
+            # the "tuning CV folds" coincide (the tuning counts toward n_reps).
+            splitter = StratifiedShuffleSplit(
+                n_splits=self.n_reps,
                 test_size=self.test_prop,
-                stratify=mi_y,
-                random_state=split[rep],
-                shuffle=True,
+                random_state=split[0],
             )
+            fold_splits = list(splitter.split(mi_x, mi_y))
+        else:
+            # Legacy path: variable random states per rep (one resample each).
+            indices = np.arange(len(mi_y))
+            fold_splits = [
+                train_test_split(
+                    indices,
+                    test_size=self.test_prop,
+                    stratify=mi_y,
+                    random_state=split[rep],
+                    shuffle=True,
+                )
+                for rep in range(self.n_reps)
+            ]
+
+        mia_metrics: list[dict] = []
+        for rep, (train_idx, test_idx) in enumerate(fold_splits):
+            logger.info("Rep %d of %d", rep + 1, self.n_reps)
+            mi_train_x, mi_test_x = mi_x[train_idx], mi_x[test_idx]
+            mi_train_y, mi_test_y = mi_y[train_idx], mi_y[test_idx]
 
             attack_classifier = self._get_attack_model()
             attack_classifier.fit(mi_train_x, mi_train_y)
@@ -466,6 +654,8 @@ class WorstCaseAttack(Attack):
         self.metadata["baseline_global_metrics"] = self._get_global_metrics(
             self._unpack_dummy_attack_metrics_experiments_instances()
         )
+        if self._tuning_info is not None:
+            self.metadata["tuning"] = self._tuning_info
 
     def _unpack_dummy_attack_metrics_experiments_instances(self) -> list:
         """Construct the metadata object after attacks."""

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -44,6 +44,14 @@ _DEFAULT_PARAM_GRIDS: dict[str, dict[str, list]] = {
     },
 }
 
+# Default hyperparameters used when attack_model is RandomForestClassifier
+# and the user did not supply `attack_model_params`.
+_DEFAULT_RF_PARAMS: dict[str, object] = {
+    "min_samples_split": 20,
+    "min_samples_leaf": 10,
+    "max_depth": 5,
+}
+
 
 class WorstCaseAttack(Attack):
     """Worst case attack."""
@@ -148,8 +156,17 @@ class WorstCaseAttack(Attack):
             msg = f"search_n_iter must be a positive integer; got {search_n_iter!r}."
             raise ValueError(msg)
         self.search_n_iter: int = search_n_iter
-        resolve_scorer(tuning_metric)
-        self.tuning_metric: str | Callable = tuning_metric
+        try:
+            self._resolved_tuning_scorer: str | Callable = resolve_scorer(tuning_metric)
+            self.tuning_metric: str | Callable = tuning_metric
+        except ValueError as exc:
+            logger.warning(
+                "Invalid tuning_metric %r (%s); falling back to 'AUC'.",
+                tuning_metric,
+                exc,
+            )
+            self.tuning_metric = "AUC"
+            self._resolved_tuning_scorer = resolve_scorer("AUC")
         self.dummy_attack_metrics: list = []
         self._tuned_params: dict | None = None
         self._tuning_info: dict | None = None
@@ -305,16 +322,14 @@ class WorstCaseAttack(Attack):
         if self._tuned_params is not None:
             return model(**self._tuned_params)
         params: dict[str, object] | None = self.attack_model_params
-        if (  # set custom default parameters for RF attack model
-            self.attack_model == "sklearn.ensemble.RandomForestClassifier"
-            and self.attack_model_params is None
+        # set custom default parameters for RF attack model
+        if (
+            params is None
+            and self.attack_model == "sklearn.ensemble.RandomForestClassifier"
         ):
-            params = {
-                "min_samples_split": 20,
-                "min_samples_leaf": 10,
-                "max_depth": 5,
-            }
-        # instantiate attack model
+            params = _DEFAULT_RF_PARAMS
+        # Fallthrough: only reached when attack_model is not RF AND the user
+        # did not supply attack_model_params -- instantiate with sklearn defaults.
         return model(**params) if params is not None else model()
 
     def _make_rep_splitter(self, random_state: int) -> StratifiedShuffleSplit:
@@ -373,7 +388,7 @@ class WorstCaseAttack(Attack):
             )
             raise ValueError(msg)
         splitter = self._make_rep_splitter(random_state)
-        scorer = resolve_scorer(self.tuning_metric)
+        scorer = self._resolved_tuning_scorer
         base_estimator = self._get_attack_model()
         if self.search_type == "grid":
             search = GridSearchCV(

--- a/tests/attacks/test_scorers.py
+++ b/tests/attacks/test_scorers.py
@@ -1,0 +1,74 @@
+"""Tests for sklearn-compatible MIA scorers in sacroml.attacks._scorers."""
+
+from __future__ import annotations
+
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+
+from sacroml import metrics
+from sacroml.attacks._scorers import SCORERS, _score_from_metrics, resolve_scorer
+
+
+@pytest.fixture(name="fitted_rf")
+def fixture_fitted_rf():
+    """Return a small RandomForestClassifier fit on a synthetic 2-class problem."""
+    X, y = make_classification(
+        n_samples=200,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    clf = RandomForestClassifier(n_estimators=10, random_state=0)
+    clf.fit(X, y)
+    return clf, X, y
+
+
+@pytest.mark.parametrize("name", list(SCORERS.keys()))
+def test_scorer_returns_float(fitted_rf, name):
+    """Each SCORERS entry yields a float when called via the sklearn protocol."""
+    clf, X, y = fitted_rf
+    score = SCORERS[name](clf, X, y)
+    assert isinstance(score, float)
+
+
+def test_resolve_scorer_callable_passthrough():
+    """Resolve_scorer returns the input unchanged when given a callable."""
+
+    def my_scorer(*_args):
+        return 0.0
+
+    assert resolve_scorer(my_scorer) is my_scorer
+
+
+def test_resolve_scorer_known_mia_name():
+    """Resolve_scorer returns the SCORERS entry for a known MIA string."""
+    assert resolve_scorer("AUC") is SCORERS["AUC"]
+
+
+def test_resolve_scorer_sklearn_string_passthrough():
+    """A recognised sklearn scoring string is returned unchanged."""
+    assert resolve_scorer("roc_auc") == "roc_auc"
+
+
+def test_resolve_scorer_unknown_string_raises():
+    """An unrecognised string raises ValueError listing the MIA scorers."""
+    with pytest.raises(ValueError, match="AUC"):
+        resolve_scorer("not_a_real_scorer")
+
+
+def test_score_from_metrics_bogus_key_raises(fitted_rf):
+    """A bogus key raises KeyError whose message lists the available keys."""
+    clf, X, y = fitted_rf
+    with pytest.raises(KeyError, match="AUC"):
+        _score_from_metrics(clf, X, y, key="DEFINITELY_NOT_A_KEY")
+
+
+def test_scorer_value_matches_get_metrics(fitted_rf):
+    """A SCORERS entry returns the same value as a direct get_metrics lookup."""
+    clf, X, y = fitted_rf
+    direct = metrics.get_metrics(clf.predict_proba(X), y)["AUC"]
+    via_scorer = SCORERS["AUC"](clf, X, y)
+    assert via_scorer == pytest.approx(float(direct))

--- a/tests/attacks/test_scorers.py
+++ b/tests/attacks/test_scorers.py
@@ -59,6 +59,12 @@ def test_resolve_scorer_unknown_string_raises():
         resolve_scorer("not_a_real_scorer")
 
 
+def test_resolve_scorer_non_string_non_callable_raises():
+    """A non-string, non-callable input raises ValueError."""
+    with pytest.raises(ValueError, match="callable or a string"):
+        resolve_scorer(123)
+
+
 def test_score_from_metrics_bogus_key_raises(fitted_rf):
     """A bogus key raises KeyError whose message lists the available keys."""
     clf, X, y = fitted_rf

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -222,6 +222,10 @@ def test_tuning_default_grid(common_setup):
     # The candidate with rank 1 should carry the reported best_params.
     best_candidate = next(c for c in tuning["cv_results"] if c["rank_test_score"] == 1)
     assert best_candidate["params"] == tuning["best_params"]
+    # Per-fold scores for the winner: one per rep, all finite floats.
+    per_fold = tuning["best_candidate_per_fold_scores"]
+    assert len(per_fold) == 3
+    assert all(isinstance(s, float) for s in per_fold)
 
 
 def test_tuning_custom_grid_reused_by_dummies(common_setup):
@@ -320,6 +324,20 @@ def test_tuning_invalid_search_type_raises(common_setup):
     )
     with pytest.raises(ValueError, match="Unknown search_type"):
         attack_obj.attack(target)
+
+
+def test_init_rejects_bad_search_n_iter():
+    """`search_n_iter` must be a positive integer."""
+    with pytest.raises(ValueError, match="search_n_iter"):
+        worst_case_attack.WorstCaseAttack(search_n_iter=0)
+    with pytest.raises(ValueError, match="search_n_iter"):
+        worst_case_attack.WorstCaseAttack(search_n_iter=-1)
+
+
+def test_init_rejects_bad_tuning_metric():
+    """An unknown `tuning_metric` string fails at construction, not at fit."""
+    with pytest.raises(ValueError, match="Unknown scorer"):
+        worst_case_attack.WorstCaseAttack(tuning_metric="not-a-real-metric")
 
 
 def test_no_tuning_leaves_metadata_clean(common_setup):

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -189,3 +189,149 @@ def test_wc_multiclass(get_target_multiclass):
     metrics = output["attack_experiment_logger"]["attack_instance_logger"]["instance_0"]
     assert 0 <= metrics["TPR"] <= 1
     assert 0 <= metrics["FPR"] <= 1
+
+
+def test_tuning_default_grid(common_setup):
+    """The "default" shortcut tunes the RF attack model and reports best params."""
+    target = common_setup
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=3,
+        n_dummy_reps=0,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+        attack_model_param_grid="default",
+    )
+    output = attack_obj.attack(target)
+
+    assert len(attack_obj.attack_metrics) == 3
+    tuning = output["metadata"]["tuning"]
+    assert tuning["search_type"] == "grid"
+    assert tuning["tuning_metric"] == "AUC"
+    # RF default grid keys should drive best_params.
+    assert set(tuning["best_params"]).issubset(
+        {"min_samples_split", "min_samples_leaf", "max_depth"}
+    )
+    assert tuning["n_candidates"] == 3 * 3 * 3
+    assert attack_obj._tuned_params is not None
+    # cv_results summary: one entry per candidate, with score + rank columns.
+    assert len(tuning["cv_results"]) == tuning["n_candidates"]
+    expected_cols = {"params", "mean_test_score", "std_test_score", "rank_test_score"}
+    assert set(tuning["cv_results"][0]) == expected_cols
+    ranks = sorted(c["rank_test_score"] for c in tuning["cv_results"])
+    assert ranks[0] == 1  # best candidate has rank 1
+    # The candidate with rank 1 should carry the reported best_params.
+    best_candidate = next(c for c in tuning["cv_results"] if c["rank_test_score"] == 1)
+    assert best_candidate["params"] == tuning["best_params"]
+
+
+def test_tuning_custom_grid_reused_by_dummies(common_setup):
+    """A custom dict grid is honoured and tuned params are reused for dummies."""
+    target = common_setup
+    grid = {
+        "min_samples_split": [2, 20],
+        "max_depth": [3, None],
+    }
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=2,
+        n_dummy_reps=1,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+        attack_model_param_grid=grid,
+    )
+    output = attack_obj.attack(target)
+
+    assert len(attack_obj.attack_metrics) == 2
+    assert len(attack_obj.dummy_attack_metrics) == 1
+    tuning = output["metadata"]["tuning"]
+    assert set(tuning["best_params"]).issubset({"min_samples_split", "max_depth"})
+    assert tuning["n_candidates"] == 4
+    # Dummies must reuse the same tuned params; tuning should run exactly once.
+    assert attack_obj._tuning_info is tuning or attack_obj._tuning_info == tuning
+
+
+def test_tuning_random_search_with_alt_scorer(common_setup):
+    """Randomised search with a non-default MIA scorer."""
+    target = common_setup
+    grid = {
+        "min_samples_split": [2, 5, 10, 20],
+        "max_depth": [3, 5, 10, None],
+    }
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=3,
+        n_dummy_reps=0,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+        attack_model_param_grid=grid,
+        search_type="random",
+        search_n_iter=3,
+        tuning_metric="TPR@0.1",
+    )
+    output = attack_obj.attack(target)
+
+    tuning = output["metadata"]["tuning"]
+    assert tuning["search_type"] == "random"
+    assert tuning["tuning_metric"] == "TPR@0.1"
+    assert tuning["n_candidates"] == 3
+
+
+def test_tuning_requires_n_reps_at_least_two(common_setup):
+    """A single rep cannot drive cross-validation."""
+    target = common_setup
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=1,
+        n_dummy_reps=0,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+        attack_model_param_grid="default",
+    )
+    with pytest.raises(ValueError, match="n_reps >= 2"):
+        attack_obj.attack(target)
+
+
+def test_tuning_default_for_unknown_model_raises():
+    """The "default" shortcut errors when no default exists for the model."""
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        attack_model="sklearn.svm.SVC",
+        attack_model_param_grid="default",
+    )
+    with pytest.raises(ValueError, match="No default param grid"):
+        attack_obj._resolve_param_grid()
+
+
+def test_tuning_invalid_grid_string_raises():
+    """Any string other than "default" is rejected."""
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        attack_model_param_grid="not-a-real-shortcut",
+    )
+    with pytest.raises(ValueError, match="must be a dict"):
+        attack_obj._resolve_param_grid()
+
+
+def test_tuning_invalid_search_type_raises(common_setup):
+    """An unrecognised search_type raises a clear error."""
+    target = common_setup
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=2,
+        n_dummy_reps=0,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+        attack_model_param_grid={"min_samples_split": [2, 20]},
+        search_type="bogus",
+    )
+    with pytest.raises(ValueError, match="Unknown search_type"):
+        attack_obj.attack(target)
+
+
+def test_no_tuning_leaves_metadata_clean(common_setup):
+    """When no grid is supplied, metadata has no "tuning" key."""
+    target = common_setup
+    attack_obj = worst_case_attack.WorstCaseAttack(
+        n_reps=2,
+        n_dummy_reps=0,
+        test_prop=0.5,
+        output_dir="test_output_worstcase",
+    )
+    output = attack_obj.attack(target)
+    assert "tuning" not in output["metadata"]
+    assert attack_obj._tuned_params is None
+    assert attack_obj._tuning_info is None

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -334,10 +334,15 @@ def test_init_rejects_bad_search_n_iter():
         worst_case_attack.WorstCaseAttack(search_n_iter=-1)
 
 
-def test_init_rejects_bad_tuning_metric():
-    """An unknown `tuning_metric` string fails at construction, not at fit."""
-    with pytest.raises(ValueError, match="Unknown scorer"):
-        worst_case_attack.WorstCaseAttack(tuning_metric="not-a-real-metric")
+def test_init_bad_tuning_metric_falls_back_to_auc(caplog):
+    """An unknown `tuning_metric` warns and falls back to AUC at construction."""
+    with caplog.at_level("WARNING", logger="sacroml.attacks.worst_case_attack"):
+        attack_obj = worst_case_attack.WorstCaseAttack(
+            tuning_metric="not-a-real-metric"
+        )
+    assert attack_obj.tuning_metric == "AUC"
+    assert callable(attack_obj._resolved_tuning_scorer)
+    assert any("not-a-real-metric" in rec.message for rec in caplog.records)
 
 
 def test_no_tuning_leaves_metadata_clean(common_setup):


### PR DESCRIPTION
## what

adds sklearn-compatible scorers wrapping `sacroml.metrics.get_metrics` so mia metrics can be passed to `gridsearchcv` / `randomizedsearchcv` via the standard `(estimator, X, y)` protocol.

## files

- `sacroml/attacks/_scorers.py`: `SCORERS` dict (auc, tpr@0.1, tpr@0.001, fdif01, fdif02, advantage, pdif01) + `resolve_scorer()` helper that also passes sklearn scoring strings through unchanged.
- `tests/attacks/test_scorers.py`: 7 tests covering protocol, value parity with `get_metrics`, passthrough, and error paths.

## why

groundwork for #350. `worstcaseattack` is not modified in this pr. follow-up pr will add `attack_model_param_grid` and `tuning_metric` and use these scorers as the search `scoring=` argument.

## status

draft, opened to review the scorer surface before wiring into the attack.