### PR TITLE
feat(pytorch): capture batch_size as optional Target parameter

### DIFF
--- a/examples/pytorch/cifar/train_pytorch.py
+++ b/examples/pytorch/cifar/train_pytorch.py
@@ -35,9 +35,16 @@ if __name__ == "__main__":
     # Create data splits
     indices_train, indices_test = data_handler.get_train_test_indices()
 
-    # Get dataloaders
-    train_loader = data_handler.get_dataloader(dataset, indices_train, shuffle=True)
-    test_loader = data_handler.get_dataloader(dataset, indices_test, shuffle=False)
+    # Get dataloaders. The batch size is made explicit here so the same value
+    # can be recorded on the Target below; it materially affects attack model
+    # fidelity (e.g. shadow models), so it must match the training batch size.
+    batch_size = 32
+    train_loader = data_handler.get_dataloader(
+        dataset, indices_train, batch_size=batch_size, shuffle=True
+    )
+    test_loader = data_handler.get_dataloader(
+        dataset, indices_test, batch_size=batch_size, shuffle=False
+    )
 
     logging.info("Defining the model")
 
@@ -69,6 +76,7 @@ if __name__ == "__main__":
         model_params=model_params,  # Must match all required in model constructor
         train_module_path="train.py",
         train_params=train_params,  # Must match all required in the train function
+        batch_size=batch_size,  # Should match the training batch size
         dataset_module_path="dataset.py",
         dataset_name="Cifar10",  # Must match the class name in dataset module
         indices_train=indices_train,

--- a/examples/pytorch/cifar/train_pytorch.py
+++ b/examples/pytorch/cifar/train_pytorch.py
@@ -35,9 +35,7 @@ if __name__ == "__main__":
     # Create data splits
     indices_train, indices_test = data_handler.get_train_test_indices()
 
-    # Get dataloaders. The batch size is made explicit here so the same value
-    # can be recorded on the Target below; it materially affects attack model
-    # fidelity (e.g. shadow models), so it must match the training batch size.
+    # Made explicit so the same value can be recorded on the Target below.
     batch_size = 32
     train_loader = data_handler.get_dataloader(
         dataset, indices_train, batch_size=batch_size, shuffle=True

--- a/examples/pytorch/simple/train_pytorch.py
+++ b/examples/pytorch/simple/train_pytorch.py
@@ -35,9 +35,16 @@ if __name__ == "__main__":
     # Create data splits
     indices_train, indices_test = data_handler.get_train_test_indices()
 
-    # Get dataloaders
-    train_loader = data_handler.get_dataloader(dataset, indices_train, shuffle=True)
-    test_loader = data_handler.get_dataloader(dataset, indices_test, shuffle=False)
+    # Get dataloaders. The batch size is made explicit here so the same value
+    # can be recorded on the Target below; it materially affects attack model
+    # fidelity (e.g. shadow models), so it must match the training batch size.
+    batch_size = 32
+    train_loader = data_handler.get_dataloader(
+        dataset, indices_train, batch_size=batch_size, shuffle=True
+    )
+    test_loader = data_handler.get_dataloader(
+        dataset, indices_test, batch_size=batch_size, shuffle=False
+    )
 
     logging.info("Defining the model")
 
@@ -71,6 +78,7 @@ if __name__ == "__main__":
         model_params=model_params,  # Must match all required in model constructor
         train_module_path="train.py",
         train_params=train_params,  # Must match all required in the train function
+        batch_size=batch_size,  # Should match the training batch size
         dataset_module_path="dataset.py",
         dataset_name="Synthetic",  # Must match the class name in dataset module
         indices_train=indices_train,

--- a/examples/pytorch/simple/train_pytorch.py
+++ b/examples/pytorch/simple/train_pytorch.py
@@ -35,9 +35,7 @@ if __name__ == "__main__":
     # Create data splits
     indices_train, indices_test = data_handler.get_train_test_indices()
 
-    # Get dataloaders. The batch size is made explicit here so the same value
-    # can be recorded on the Target below; it materially affects attack model
-    # fidelity (e.g. shadow models), so it must match the training batch size.
+    # Made explicit so the same value can be recorded on the Target below.
     batch_size = 32
     train_loader = data_handler.get_dataloader(
         dataset, indices_train, batch_size=batch_size, shuffle=True

--- a/sacroml/attacks/model_pytorch.py
+++ b/sacroml/attacks/model_pytorch.py
@@ -30,6 +30,7 @@ class PytorchModel(Model):
         model_params: dict | None = None,
         train_module_path: str = "",
         train_params: dict | None = None,
+        batch_size: int = 32,
     ) -> None:
         """Instantiate a target model.
 
@@ -49,6 +50,10 @@ class PytorchModel(Model):
             Path (including extension) of Python module containing train function.
         train_params : dict | None
             Hyperparameters for training the model.
+        batch_size : int
+            Batch size used to (re)train and run inference on the model. Should
+            match the batch size used to train the original target model, since
+            it materially affects attack model fidelity (e.g. shadow models).
         """
         super().__init__(
             model=model,
@@ -59,6 +64,7 @@ class PytorchModel(Model):
             train_module_path=train_module_path,
             train_params=train_params,
         )
+        self.batch_size: int = batch_size
 
     def get_generalisation_error(
         self,
@@ -150,7 +156,9 @@ class PytorchModel(Model):
         # Create a dataloader
         X_tensor = torch.from_numpy(X).float()
         dataset = TensorDataset(X_tensor)
-        dataloader: DataLoader = DataLoader(dataset, batch_size=32, shuffle=False)
+        dataloader: DataLoader = DataLoader(
+            dataset, batch_size=self.batch_size, shuffle=False
+        )
 
         # Compute predictions
         all_preds = []
@@ -165,7 +173,9 @@ class PytorchModel(Model):
         self.model.to("cpu")
         return all_preds.numpy().astype(np.float64)
 
-    def fit(self, X: np.ndarray, y: np.ndarray) -> PytorchModel:
+    def fit(
+        self, X: np.ndarray, y: np.ndarray, batch_size: int | None = None
+    ) -> PytorchModel:
         """Fit a model from scratch.
 
         Parameters
@@ -174,18 +184,36 @@ class PytorchModel(Model):
             Features of the samples to be fitted.
         y : np.ndarray
             Labels of the samples to be fitted.
+        batch_size : int | None
+            Optional override for the batch size. When ``None`` (default) the
+            batch size recorded on the model is used. When supplied and it
+            differs from the recorded batch size a warning is emitted, since a
+            mismatch can materially affect attack model fidelity.
 
         Returns
         -------
         self
             Fitted model.
         """
+        fit_batch_size: int = self.batch_size
+        if batch_size is not None and batch_size != self.batch_size:
+            logger.warning(
+                "fit() called with batch_size=%d which differs from the "
+                "target's recorded batch_size=%d; this can materially affect "
+                "attack model fidelity (e.g. shadow models).",
+                batch_size,
+                self.batch_size,
+            )
+            fit_batch_size = batch_size
+
         #  Create a new model using the provided model class
         self.model = create_model(
             self.model_module_path, self.model_name, self.model_params
         )
         # Create a dataloader
-        dataloader: DataLoader = numpy_to_dataloader(X, y, batch_size=32, shuffle=True)
+        dataloader: DataLoader = numpy_to_dataloader(
+            X, y, batch_size=fit_batch_size, shuffle=True
+        )
         #  Fit using the provided train function
         return train_model(
             self.model, self.train_module_path, self.train_params, dataloader
@@ -209,6 +237,7 @@ class PytorchModel(Model):
             model_params=self.model_params,
             train_module_path=self.train_module_path,
             train_params=self.train_params,
+            batch_size=self.batch_size,
         )
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
@@ -231,7 +260,9 @@ class PytorchModel(Model):
         # Create a dataloader
         X_tensor = torch.from_numpy(X).float()
         dataset = TensorDataset(X_tensor)
-        dataloader: DataLoader = DataLoader(dataset, batch_size=32, shuffle=False)
+        dataloader: DataLoader = DataLoader(
+            dataset, batch_size=self.batch_size, shuffle=False
+        )
 
         # Compute the probabilities
         all_probs = []
@@ -331,6 +362,7 @@ class PytorchModel(Model):
         model_params: dict,
         train_module_path: str,
         train_params: dict,
+        batch_size: int = 32,
     ) -> PytorchModel:
         """Load the model from persistent storage.
 
@@ -348,6 +380,8 @@ class PytorchModel(Model):
             Path (including extension) of Python module containing train function.
         train_params : dict
             Hyperparameters for training the model.
+        batch_size : int
+            Batch size used to (re)train and run inference on the model.
 
         Returns
         -------
@@ -371,6 +405,7 @@ class PytorchModel(Model):
             model_params=model_params,
             train_module_path=train_module_path,
             train_params=train_params,
+            batch_size=batch_size,
         )
 
 

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -80,6 +80,11 @@ class Target:
         Path to module containing training function.
     train_params : dict or None
         Hyperparameters for training the model.
+    batch_size : int or None
+        Batch size used to train the original target model. Threaded to
+        PyTorch model (re)training and inference. Should match the original
+        training batch size since it materially affects attack model fidelity
+        (e.g. shadow models). When None, PyTorch defaults to 32.
     dataset_name : str
         The name of the dataset.
     dataset_module_path : str
@@ -122,6 +127,7 @@ class Target:
     model_params: dict | None = None
     train_module_path: str = ""
     train_params: dict | None = None
+    batch_size: int | None = None
 
     # Dataset attributes
     dataset_name: str = ""
@@ -165,6 +171,10 @@ class Target:
                 train_params=self.train_params,
             )
         if isinstance(model, torch.nn.Module):
+            # Resolve None -> 32 silently here: _wrap_model() runs per Target
+            # construction (and once per shadow model in LiRA), so warning here
+            # would spam the log. The unspecified-batch-size warning instead
+            # fires exactly once at load time in _load_model().
             return PytorchModel(
                 model=model,
                 model_path=self.model_path,
@@ -173,6 +183,7 @@ class Target:
                 model_params=self.model_params,
                 train_module_path=self.train_module_path,
                 train_params=self.train_params,
+                batch_size=self.batch_size if self.batch_size is not None else 32,
             )
         if isinstance(model, (SklearnModel, PytorchModel)):
             return model
@@ -373,6 +384,12 @@ class Target:
             }
         )
 
+        # batch_size is Target-level metadata, persisted as a top-level scalar
+        # (not nested in train_params, which is forwarded verbatim as kwargs to
+        # the user's train() function).
+        if isinstance(self.model, PytorchModel):
+            target["batch_size"] = self.model.batch_size
+
         # Copy module files
         if self.model_module_path:
             shutil.copy2(self.model_module_path, os.path.join(path, "model.py"))
@@ -422,14 +439,36 @@ class Target:
         model_class: type[SklearnModel] | type[PytorchModel] = MODEL_REGISTRY[
             model_type
         ]
-        self.model = model_class.load(
-            model_path=os.path.join(path, target.get("model_path", "")),
-            model_module_path=os.path.join(path, target.get("model_module_path", "")),
-            model_name=target.get("model_name", ""),
-            model_params=target.get("model_params", {}),
-            train_module_path=os.path.join(path, target.get("train_module_path", "")),
-            train_params=target.get("train_params", {}),
-        )
+        load_kwargs: dict[str, object] = {
+            "model_path": os.path.join(path, target.get("model_path", "")),
+            "model_module_path": os.path.join(
+                path, target.get("model_module_path", "")
+            ),
+            "model_name": target.get("model_name", ""),
+            "model_params": target.get("model_params", {}),
+            "train_module_path": os.path.join(
+                path, target.get("train_module_path", "")
+            ),
+            "train_params": target.get("train_params", {}),
+        }
+
+        # batch_size only applies to PyTorch models. _load_model() is called
+        # exactly once per Target.load(), so emitting the warning here (rather
+        # than in _wrap_model(), which runs per shadow model) guarantees it
+        # fires exactly once for an old target.yaml lacking the key. No dedupe
+        # flag or warnings filter is needed.
+        if model_class is PytorchModel:
+            if "batch_size" not in target:
+                logger.warning(
+                    "Saved target has no recorded batch_size; defaulting to "
+                    "32. This may not match the original training batch size "
+                    "and can materially affect attack model fidelity "
+                    "(e.g. shadow models in LiRA)."
+                )
+            load_kwargs["batch_size"] = target.get("batch_size", 32)
+            self.batch_size = target.get("batch_size", 32)
+
+        self.model = model_class.load(**load_kwargs)
         logger.info("Loaded: %s : %s", model_type, target.get("model_name", ""))
 
     def _load_array(self, path: str, target: dict, attr_name: str) -> None:

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -171,10 +171,6 @@ class Target:
                 train_params=self.train_params,
             )
         if isinstance(model, torch.nn.Module):
-            # Resolve None -> 32 silently here: _wrap_model() runs per Target
-            # construction (and once per shadow model in LiRA), so warning here
-            # would spam the log. The unspecified-batch-size warning instead
-            # fires exactly once at load time in _load_model().
             return PytorchModel(
                 model=model,
                 model_path=self.model_path,
@@ -384,9 +380,6 @@ class Target:
             }
         )
 
-        # batch_size is Target-level metadata, persisted as a top-level scalar
-        # (not nested in train_params, which is forwarded verbatim as kwargs to
-        # the user's train() function).
         if isinstance(self.model, PytorchModel):
             target["batch_size"] = self.model.batch_size
 
@@ -452,11 +445,6 @@ class Target:
             "train_params": target.get("train_params", {}),
         }
 
-        # batch_size only applies to PyTorch models. _load_model() is called
-        # exactly once per Target.load(), so emitting the warning here (rather
-        # than in _wrap_model(), which runs per shadow model) guarantees it
-        # fires exactly once for an old target.yaml lacking the key. No dedupe
-        # flag or warnings filter is needed.
         if model_class is PytorchModel:
             if "batch_size" not in target:
                 logger.warning(

--- a/tests/attacks/test_pytorch.py
+++ b/tests/attacks/test_pytorch.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
+import numpy as np
 import torch
+import yaml
 
 from sacroml.attacks.attribute_attack import AttributeAttack
 from sacroml.attacks.likelihood_attack import LIRAAttack
@@ -137,3 +141,108 @@ def test_pytorch() -> None:
     indices = tgt.model.get_label_indices(tgt.y_test)
     for i in range(len(tgt.y_test)):
         assert testloss[i] == 1.0 - predictions[i][indices[i]]
+
+
+def _make_target(batch_size: int | None) -> Target:
+    """Build a small wrapped PyTorch Target for batch_size tests."""
+    handler = Synthetic()
+    dataset = handler.get_dataset()
+    indices_train, indices_test = handler.get_train_test_indices()
+    train_loader = handler.get_dataloader(dataset, indices_train)
+
+    model_params = {"x_dim": 4, "y_dim": 4, "n_units": 1000}
+    train_params = {"epochs": 1, "learning_rate": 0.001, "momentum": 0.9}
+    model = OverfitNet(**model_params)
+    train(model, train_loader, **train_params)
+
+    return Target(
+        model=model,
+        model_module_path="tests/attacks/pytorch_model.py",
+        model_params=model_params,
+        train_module_path="tests/attacks/pytorch_train.py",
+        train_params=train_params,
+        batch_size=batch_size,
+        dataset_module_path="tests/attacks/pytorch_dataset.py",
+        dataset_name="Synthetic",
+        indices_train=indices_train,
+        indices_test=indices_test,
+    )
+
+
+def test_batch_size_roundtrip() -> None:
+    """An explicit batch_size survives Target.save() / load()."""
+    target = _make_target(batch_size=64)
+    assert target.model.batch_size == 64
+
+    target_path = "target_pytorch_bs"
+    target.save(target_path)
+
+    # Top-level scalar in target.yaml, not nested inside train_params.
+    with open(f"{target_path}/target.yaml", encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+    assert saved["batch_size"] == 64
+    assert "batch_size" not in saved.get("train_params", {})
+
+    tgt = Target()
+    tgt.load(target_path)
+    assert tgt.batch_size == 64
+    assert tgt.model.batch_size == 64
+
+
+def test_batch_size_defaults_to_32_when_unset() -> None:
+    """An unset batch_size resolves to 32 on the wrapped model (no warning)."""
+    target = _make_target(batch_size=None)
+    assert target.model.batch_size == 32
+
+    target_path = "target_pytorch_bs_none"
+    target.save(target_path)
+    # A freshly-saved target records the resolved value (32), not None.
+    with open(f"{target_path}/target.yaml", encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+    assert saved["batch_size"] == 32
+
+
+def test_batch_size_backcompat_old_yaml(caplog) -> None:
+    """A hand-crafted old target.yaml lacking batch_size loads as 32 and warns.
+
+    This deliberately writes the yaml by hand (rather than saving a Target
+    with batch_size=None) because the absent-key path is distinct from the
+    resolved-to-32 save path.
+    """
+    target = _make_target(batch_size=128)
+    target_path = "target_pytorch_old"
+    target.save(target_path)
+
+    yaml_path = f"{target_path}/target.yaml"
+    with open(yaml_path, encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+    del saved["batch_size"]
+    assert "batch_size" not in saved
+    with open(yaml_path, "w", encoding="utf-8") as f:
+        yaml.dump(saved, f, default_flow_style=False, sort_keys=False)
+
+    tgt = Target()
+    with caplog.at_level(logging.WARNING, logger="sacroml.attacks.target"):
+        tgt.load(target_path)
+
+    assert tgt.model.batch_size == 32
+    warnings = [
+        r
+        for r in caplog.records
+        if "no recorded batch_size" in r.message and r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
+
+
+def test_fit_batch_size_override_warns(caplog) -> None:
+    """Fit() warns when an explicit batch_size differs from the recorded one."""
+    target = _make_target(batch_size=16)
+    handler = Synthetic()
+    X = np.asarray(handler.X, dtype=np.float64)
+    y = np.asarray(handler.y, dtype=np.int64)
+
+    with caplog.at_level(logging.WARNING, logger="sacroml.attacks.model_pytorch"):
+        target.model.fit(X, y, batch_size=8)
+
+    warnings = [r for r in caplog.records if "differs from the target" in r.message]
+    assert len(warnings) == 1


### PR DESCRIPTION
closes #447

## what

the pytorch wrapper hardcoded `batch_size=32` for (re)training and inference. batch size strongly affects model behaviour, so shadow models at 32 may not match a target trained differently, distorting attack results (e.g. lira). this captures `batch_size` as an optional `Target` parameter and uses it in `PytorchModel` (richard's suggested "for now" approach).

## changes

- `PytorchModel`: optional `batch_size` (default 32) on `__init__`/`load()`, used in `fit()`, `predict()`, `predict_proba()`, propagated via `clone()`.
- `fit()`: optional `batch_size` override, warns on mismatch with recorded value.
- `Target`: optional `batch_size` field, persisted in `target.yaml` as a top-level scalar (not in `train_params`).
- examples (simple + cifar): batch size made explicit, passed to both dataloader and `Target`.
- tests: round-trip, default-to-32, old-yaml back-compat, fit override warning.

## notes

- `predict`/`predict_proba` now use `self.batch_size` instead of 32. outputs unchanged (eval mode, batchnorm running stats); only memory/throughput differs.
- batch size is user-supplied, not auto-detected: the eager dataloader to numpy conversion (the still-open part of #411) leaves no batch info to recover. defaults to 32 when unset.
- default-to-32 warning fires once at load time in `_load_model()`, not per `_wrap_model()` call (avoids per-shadow-model log spam).

old targets without `batch_size` load fine, default to 32, warn once.

## out of scope

- linear lr scaling for train/assess hardware mismatch: deferred to a follow-up issue. i think it is slightly out of scope for here and deserves its own issue

## testing

57 tests pass locally (`test_pytorch`, `test_lira_attack`, `test_attacks_target`, `test_qmia_attack`, `test_worst_case_attack`, `test_factory`) plus 4 new batch_size tests.

let me know what you think, any changes etc.. @rpreen 