### PR TITLE
fix(structural): gate per-record results behind report_individual flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes:
     membership thresholds. A sample is predicted as a member when its observed score
     exceeds the predicted threshold at quantile level (1 - alpha). No shadow models or
     architecture knowledge required. Registered in the attack factory as `"qmia"`.
+*   Fix: `StructuralAttack` now respects the `report_individual` flag. Per-record
+    `record_level_results` and `attack_metrics["individual"]` are only populated when the
+    flag is set to `True`, matching the behaviour of `LIRAAttack` and `QMIAAttack`.
 
 ## Version 1.4.3 (Jan 29, 2026)
 

--- a/sacroml/attacks/structural_attack.py
+++ b/sacroml/attacks/structural_attack.py
@@ -360,6 +360,7 @@ class StructuralAttack(Attack):
         super().__init__(output_dir=output_dir, write_report=write_report)
         self.target: Target | None = None
         self.results: StructuralAttackResults | None = None
+        self.record_level_results: StructuralRecordLevelResults | None = None
         self.report_individual = report_individual
 
         # Load risk appetite from ACRO config
@@ -477,11 +478,12 @@ class StructuralAttack(Attack):
             class_disclosure_risk=global_cd,
             smallgroup_risk=global_small,
         )
-        self.record_level_results = StructuralRecordLevelResults(
-            k_anonymity=record_level_kval,
-            class_disclosure=record_level_cd,
-            smallgroup_risk=record_level_small,
-        )
+        if self.report_individual:
+            self.record_level_results = StructuralRecordLevelResults(
+                k_anonymity=record_level_kval,
+                class_disclosure=record_level_cd,
+                smallgroup_risk=record_level_small,
+            )
 
         output = self._make_report(target)
 
@@ -678,7 +680,8 @@ class StructuralAttack(Attack):
         self.attack_metrics = {}
         for key, val in asdict(self.results).items():
             self.attack_metrics[key] = val
-        self.attack_metrics["individual"] = asdict(self.record_level_results)
+        if self.report_individual and self.record_level_results:
+            self.attack_metrics["individual"] = asdict(self.record_level_results)
 
     def _get_attack_metrics_instances(self) -> dict:
         """Return attack metrics. Required by the Attack base class.

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -735,3 +735,40 @@ def test_structural_individual_externalised(tmp_path):
     assert os.path.exists(npz_path)
     with np.load(npz_path) as data:
         assert "individual.k_anonymity" in data
+
+
+def test_structural_report_individual_default_off_omits_individual():
+    """Default report_individual=False: no per-record block populated."""
+    target = get_target("dt", max_depth=1, min_samples_leaf=20, random_state=0)
+    attack = sa.StructuralAttack()
+    assert attack.report_individual is False
+
+    output = attack.attack(target)
+
+    assert attack.record_level_results is None
+    assert "individual" not in attack.attack_metrics
+    inst = output["attack_experiment_logger"]["attack_instance_logger"]["instance_0"]
+    assert "individual" not in inst
+
+
+def test_structural_report_individual_on_populates_individual():
+    """Report_individual=True populates per-record block, one entry per train row."""
+    target = get_target("dt", max_depth=1, min_samples_leaf=20, random_state=0)
+    n_train = len(target.y_train)
+
+    attack = sa.StructuralAttack(report_individual=True)
+    output = attack.attack(target)
+
+    assert attack.record_level_results is not None
+    assert len(attack.record_level_results.k_anonymity) == n_train
+    assert len(attack.record_level_results.class_disclosure) == n_train
+    assert len(attack.record_level_results.smallgroup_risk) == n_train
+
+    assert "individual" in attack.attack_metrics
+    inst = output["attack_experiment_logger"]["attack_instance_logger"]["instance_0"]
+    assert "individual" in inst
+    assert set(inst["individual"].keys()) == {
+        "k_anonymity",
+        "class_disclosure",
+        "smallgroup_risk",
+    }


### PR DESCRIPTION
closes #451

- `StructuralAttack` accepts a `report_individual` flag in its constructor, but the `record_level_results` dataclass and the `attack_metrics["individual"]` dict were populated regardless of the flag
- the existing check inside `_get_attack_metrics_instances` (line 696) was effectively dead because `record_level_results` was always truthy by the time it ran
- i wrapped the dataclass construction (line 480 to 484) and the `attack_metrics["individual"]` write (line 681) in `if self.report_individual:`
- i initialised `self.record_level_results` to `None` in `__init__` so the attribute exists before `_attack()` runs, mirroring how `LIRAAttack` gates its `result` dict
- `MetaAttack` continues to work because `meta_attack.py:530` already sets `sub_params["report_individual"] = True` for every attack it spawns, so the consumer path stays populated
- this branch is stacked on `428-meta-attack` until that PR lands, so the diff here will shrink once that merges