### PR TITLE
feat(meta): add struct_vuln_rule option for combining structural risk flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Changes:
     (multi-section, as produced when individual attacks append to the same file)
     and any subdirectory-per-attack layout. Registered in the attack factory as
     `"meta"`.
+*   Feat: `MetaAttack`: new `struct_vuln_rule` option selecting how per-record
+    structural indicators (k-anonymity below threshold, class disclosure,
+    small-group risk) combine into the `struct_vuln` flag: `'or'` (default,
+    unchanged behaviour) or `'and'`. Combination logic moved to
+    `structural_attack.combine_risk_flags()`
+    ([#464](https://github.com/AI-SDC/SACRO-ML/issues/464)).
 *   Refactor: Name `InstanceBasedAttack`'s default floating-point matching tolerance as the module-level constant `INSTANCE_MATCH_ATOL = 1e-8` ([#454](https://github.com/AI-SDC/SACRO-ML/issues/454)). `StructuralAttack` is intentionally not changed because it uses exact `np.unique` equality on deterministic `predict_proba` outputs and does not need a tolerance.
 *   Feat: `QMIAAttack`: membership inference attack via quantile regression (Bertran et al.,
     NeurIPS 2023, arXiv:2307.03694). Trains a histogram-based quantile regressor

--- a/examples/sklearn/meta_attack_example.py
+++ b/examples/sklearn/meta_attack_example.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
         ],
         behaviour="run_all",  # alternatives: "use_existing_only", "fill_missing"
         mia_threshold=0.5,
+        # struct_vuln_rule="and" would require all structural indicators to flag
         output_dir=output_dir,
     )
     meta.attack(target)

--- a/sacroml/attacks/constants.py
+++ b/sacroml/attacks/constants.py
@@ -32,3 +32,22 @@ Used as the ``mia_threshold`` default for
 :class:`~sacroml.attacks.meta_attack.MetaAttack` so the value can be
 referenced symbolically from tests, examples, and documentation.
 """
+
+STRUCT_VULN_OR: str = "or"
+"""Combination rule: a record is structurally vulnerable when ANY indicator
+fires (k-anonymity below threshold, class disclosure, or small-group risk).
+
+The cautious default: over-flagging is safer than under-flagging in
+disclosure control.
+"""
+
+STRUCT_VULN_AND: str = "and"
+"""Combination rule: a record is structurally vulnerable only when ALL
+indicators fire.
+"""
+
+STRUCT_VULN_RULES: frozenset[str] = frozenset({STRUCT_VULN_OR, STRUCT_VULN_AND})
+"""Valid values for :func:`sacroml.attacks.structural_attack.combine_risk_flags`
+and the ``struct_vuln_rule`` parameter of
+:class:`~sacroml.attacks.meta_attack.MetaAttack`.
+"""

--- a/sacroml/attacks/meta_attack.py
+++ b/sacroml/attacks/meta_attack.py
@@ -6,7 +6,8 @@ a unified pandas DataFrame with two-level aggregation:
 
   Level 1 — within-attack: mean, std, and consistency across repeated runs.
   Level 2 — cross-attack:  arithmetic/geometric mean of MIA scores,
-            binary structural flag, and total vulnerability count.
+            binary structural flag (rule selectable via ``struct_vuln_rule``),
+            and total vulnerability count.
 
 Supports three operating modes via the *behaviour* parameter:
 
@@ -41,7 +42,13 @@ from fpdf import FPDF
 
 from sacroml import metrics
 from sacroml.attacks.attack import Attack
-from sacroml.attacks.constants import DEFAULT_MIA_THRESHOLD, EPS_META
+from sacroml.attacks.constants import (
+    DEFAULT_MIA_THRESHOLD,
+    EPS_META,
+    STRUCT_VULN_OR,
+    STRUCT_VULN_RULES,
+)
+from sacroml.attacks.structural_attack import combine_risk_flags
 from sacroml.attacks.target import Target
 
 logger = logging.getLogger(__name__)
@@ -101,6 +108,11 @@ class MetaAttack(Attack):
     k_threshold : int or None
         k-anonymity value below which a record is structurally vulnerable.
         ``None`` reads the default from the ACRO risk-appetite config.
+    struct_vuln_rule : str
+        How per-record structural indicators combine into the
+        ``struct_vuln`` flag.  ``'or'`` (default) flags a record when any
+        indicator fires; ``'and'`` only when all fire.  See
+        :func:`sacroml.attacks.structural_attack.combine_risk_flags`.
     output_dir : str
         Directory for all outputs (sub-attack subdirectories, report, CSV).
     write_report : bool
@@ -121,6 +133,7 @@ class MetaAttack(Attack):
         report_dir: str | None = None,
         mia_threshold: float = DEFAULT_MIA_THRESHOLD,
         k_threshold: int | None = None,
+        struct_vuln_rule: str = STRUCT_VULN_OR,
         output_dir: str = "outputs",
         write_report: bool = True,
         keep_separate: bool = False,
@@ -154,6 +167,13 @@ class MetaAttack(Attack):
             self.k_threshold: int = ACRO("default").config["safe_threshold"]
         else:
             self.k_threshold = k_threshold
+
+        if struct_vuln_rule not in STRUCT_VULN_RULES:
+            raise ValueError(
+                f"Unknown struct_vuln_rule: {struct_vuln_rule!r}. "
+                f"Expected one of {sorted(STRUCT_VULN_RULES)}."
+            )
+        self.struct_vuln_rule: str = struct_vuln_rule
 
         self.vulnerability_df: pd.DataFrame | None = None
 
@@ -663,10 +683,12 @@ class MetaAttack(Attack):
             data["struct_k"] = list(k_vals) + nan_pad
             data["struct_cd"] = list(cd_vals) + none_pad
             data["struct_sg"] = list(sg_vals) + none_pad
-            data["struct_vuln"] = [
-                (k < self.k_threshold or cd or sg)
-                for k, cd, sg in zip(k_vals, cd_vals, sg_vals, strict=True)
-            ] + none_pad
+            data["struct_vuln"] = (
+                combine_risk_flags(
+                    k_vals, cd_vals, sg_vals, self.k_threshold, self.struct_vuln_rule
+                )
+                + none_pad
+            )
 
         # --- Level 2: cross-attack aggregation ---
 
@@ -734,6 +756,7 @@ class MetaAttack(Attack):
 
         gm["mia_threshold"] = self.mia_threshold
         gm["k_threshold"] = self.k_threshold
+        gm["struct_vuln_rule"] = self.struct_vuln_rule
         gm["n_records"] = len(self.vulnerability_df)
 
         if "AUC" in m:

--- a/sacroml/attacks/structural_attack.py
+++ b/sacroml/attacks/structural_attack.py
@@ -19,6 +19,7 @@ The methodology is aligned with SACRO-ML's privacy risk framework.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 
 import numpy as np
@@ -38,6 +39,7 @@ except ImportError:
 
 from sacroml.attacks import report
 from sacroml.attacks.attack import Attack
+from sacroml.attacks.constants import STRUCT_VULN_OR, STRUCT_VULN_RULES
 from sacroml.attacks.target import Target
 
 logging.basicConfig(level=logging.INFO)
@@ -94,6 +96,55 @@ Optional additional metadata, such as model-specific notes or thresholds used.
 """
 
 # --- Standalone Helper Functions for Risk Assessment ---
+
+
+def combine_risk_flags(
+    k_anonymity: Sequence[int],
+    class_disclosure: Sequence[bool],
+    smallgroup_risk: Sequence[bool],
+    k_threshold: int,
+    rule: str = STRUCT_VULN_OR,
+) -> list[bool]:
+    """Combine per-record structural risk indicators into overall flags.
+
+    A record has three indicators: k-anonymity below *k_threshold*, class
+    disclosure, and small-group risk.
+
+    Parameters
+    ----------
+    k_anonymity : Sequence[int]
+        Per-record k-anonymity values.
+    class_disclosure : Sequence[bool]
+        Per-record class disclosure indicators.
+    smallgroup_risk : Sequence[bool]
+        Per-record small-group risk indicators.
+    k_threshold : int
+        k-anonymity value below which a record is considered at risk.
+    rule : str
+        ``'or'`` (default) flags a record when any indicator fires;
+        ``'and'`` flags a record only when all indicators fire.
+
+    Returns
+    -------
+    list[bool]
+        One overall vulnerability flag per record.
+
+    Raises
+    ------
+    ValueError
+        If *rule* is unknown or the sequences have mismatched lengths.
+    """
+    if rule not in STRUCT_VULN_RULES:
+        raise ValueError(
+            f"Unknown rule: {rule!r}. Expected one of {sorted(STRUCT_VULN_RULES)}."
+        )
+    combine = any if rule == STRUCT_VULN_OR else all
+    return [
+        combine((k < k_threshold, cd, sg))
+        for k, cd, sg in zip(
+            k_anonymity, class_disclosure, smallgroup_risk, strict=True
+        )
+    ]
 
 
 def get_unnecessary_risk(model: BaseEstimator | torch.nn.Module) -> bool:

--- a/tests/attacks/test_meta_attack.py
+++ b/tests/attacks/test_meta_attack.py
@@ -712,6 +712,69 @@ def test_meta_struct_vuln_flagged_by_smallgroup_risk(meta_target, tmp_path):
     assert df.loc[df["is_member"] == 1, "struct_vuln"].all()
 
 
+def test_meta_struct_vuln_and_rule_requires_all_indicators(meta_target, tmp_path):
+    """AND rule flags only records where all three indicators fire."""
+    n_train = len(meta_target.X_train)
+    n_test = len(meta_target.X_test)
+    meta = MetaAttack(
+        attacks=[("structural", {})],
+        output_dir=str(tmp_path / "meta"),
+        write_report=False,
+        k_threshold=5,
+        struct_vuln_rule="and",
+    )
+    # record 0 fires all three indicators; later records miss at least one
+    reps = [
+        {
+            "k_anonymity": [3] * n_train,
+            "class_disclosure": [True] * n_train,
+            "smallgroup_risk": [True] + [False] * (n_train - 1),
+        }
+    ]
+    df = meta._build_dataframe(n_train, n_test, {}, {"structural": reps})
+    train_flags = df.loc[df["is_member"] == 1, "struct_vuln"].tolist()
+    assert train_flags[0] is True
+    assert all(flag is False for flag in train_flags[1:])
+    assert df.loc[df["is_member"] == 0, "struct_vuln"].isna().all()
+
+
+def test_meta_struct_vuln_rule_default_is_or(tmp_path):
+    """Default struct_vuln_rule is 'or', preserving existing behaviour."""
+    meta = MetaAttack(
+        attacks=[("structural", {})],
+        output_dir=str(tmp_path / "meta"),
+        write_report=False,
+        k_threshold=5,
+    )
+    assert meta.struct_vuln_rule == "or"
+
+
+def test_meta_invalid_struct_vuln_rule_raises(tmp_path):
+    """Constructing MetaAttack with an unknown rule fails fast."""
+    with pytest.raises(ValueError, match="struct_vuln_rule"):
+        MetaAttack(
+            attacks=[("structural", {})],
+            output_dir=str(tmp_path / "meta"),
+            write_report=False,
+            k_threshold=5,
+            struct_vuln_rule="xor",
+        )
+
+
+def test_meta_struct_vuln_rule_in_report_metadata(meta_target, tmp_path):
+    """The chosen rule is recorded in global_metrics and attack_params."""
+    meta = MetaAttack(
+        attacks=[("structural", {})],
+        output_dir=str(tmp_path / "meta"),
+        write_report=False,
+        k_threshold=5,
+        struct_vuln_rule="and",
+    )
+    output = meta.attack(meta_target)
+    assert output["metadata"]["global_metrics"]["struct_vuln_rule"] == "and"
+    assert output["metadata"]["attack_params"]["struct_vuln_rule"] == "and"
+
+
 # ------------------------------------------------------------------
 # keep_separate / append-to-existing-report.json tests
 # ------------------------------------------------------------------

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -772,3 +772,58 @@ def test_structural_report_individual_on_populates_individual():
         "class_disclosure",
         "smallgroup_risk",
     }
+
+
+# ------------------------------------------------------------------
+# combine_risk_flags
+# ------------------------------------------------------------------
+
+
+def test_combine_risk_flags_or_flags_any_indicator():
+    """OR rule flags a record when any single indicator fires."""
+    k_vals = [3, 10, 10, 10]
+    cd_vals = [False, True, False, False]
+    sg_vals = [False, False, True, False]
+    flags = sa.combine_risk_flags(k_vals, cd_vals, sg_vals, 5, rule="or")
+    assert flags == [True, True, True, False]
+
+
+def test_combine_risk_flags_or_is_default_rule():
+    """Omitting rule gives OR behaviour."""
+    flags = sa.combine_risk_flags([3, 10], [False, False], [False, False], 5)
+    assert flags == [True, False]
+
+
+def test_combine_risk_flags_and_requires_all_indicators():
+    """AND rule flags only records where every indicator fires."""
+    k_vals = [3, 3, 3, 10, 10]
+    cd_vals = [True, True, False, True, False]
+    sg_vals = [True, False, True, True, False]
+    flags = sa.combine_risk_flags(k_vals, cd_vals, sg_vals, 5, rule="and")
+    assert flags == [True, False, False, False, False]
+
+
+def test_combine_risk_flags_k_equal_threshold_not_at_risk():
+    """K equal to k_threshold is not a violation under either rule."""
+    assert sa.combine_risk_flags([5], [False], [False], 5, rule="or") == [False]
+    assert sa.combine_risk_flags([5], [True], [True], 5, rule="and") == [False]
+
+
+def test_combine_risk_flags_unknown_rule_raises():
+    """An unknown rule raises ValueError naming the valid options."""
+    with pytest.raises(ValueError, match="Unknown rule") as excinfo:
+        sa.combine_risk_flags([3], [True], [True], 5, rule="xor")
+    assert "'and'" in str(excinfo.value)
+    assert "'or'" in str(excinfo.value)
+
+
+def test_combine_risk_flags_length_mismatch_raises():
+    """Mismatched sequence lengths raise ValueError via strict zip."""
+    with pytest.raises(ValueError, match=r"zip\(\)"):
+        sa.combine_risk_flags([3, 4], [True], [True, False], 5, rule="or")
+
+
+def test_combine_risk_flags_empty_returns_empty():
+    """Empty inputs give an empty flag list under both rules."""
+    assert sa.combine_risk_flags([], [], [], 5, rule="or") == []
+    assert sa.combine_risk_flags([], [], [], 5, rule="and") == []


### PR DESCRIPTION
closes #464

- `struct_vuln` in the meta attack vulnerability matrix was hard coded to flag a record when any structural indicator fired (k below threshold, class disclosure, or smallgroup risk)
- this adds a `struct_vuln_rule` option to `MetaAttack` accepting `"or"` (default, behaviour unchanged) or `"and"` so the flag can require all indicators instead, as the issue asks
- i moved the combination itself into `structural_attack.combine_risk_flags()` since as i read the issue that felt like where it belongs, next to the code that produces the indicators, happy to move it back into meta_attack.py if you'd rather
- the chosen rule shows up in `attack_params` and `global_metrics` in report.json so downstream readers can tell which rule produced the flags
- the rule is validated at construction time like `behaviour`, so a typo fails before any sub attack runs rather than mid workflow
